### PR TITLE
Operator reform

### DIFF
--- a/lib/type/list.ex
+++ b/lib/type/list.ex
@@ -106,6 +106,7 @@ defmodule Type.List do
       if Enum.all?(type.of, &match?(
             %Type.Tuple{elements: [e, _]} when is_atom(e), &1)) do
         type.of
+        |> Enum.reverse
         |> Enum.map(&List.to_tuple(&1.elements))
         |> to_doc(opts)
       else

--- a/lib/type/map.ex
+++ b/lib/type/map.ex
@@ -61,7 +61,7 @@ defmodule Type.Map do
   iex> import Type
   iex> Map.apply(Map.build(%{builtin(:neg_integer) => :foo,
   ...>                       builtin(:pos_integer) => :bar}), -5..5)
-  %Type.Union{of: [:bar, :foo]}
+  %Type.Union{of: [:foo, :bar]}
   ```
   """
   def apply(map, preimage_clamp) do

--- a/lib/type/operators.ex
+++ b/lib/type/operators.ex
@@ -2,7 +2,7 @@ defmodule Type.Operators do
   defmacro __using__(_opts) do
     quote do
       import Kernel, except: [>: 2, <: 2, <=: 2, >=: 2, in: 2]
-      import Type.Operators, only: [|: 2, ~>: 2, >: 2, <: 2, <=: 2, >=: 2, in: 2]
+      import Type.Operators, only: [<~>: 2, <|>: 2, ~>: 2, >: 2, <: 2, <=: 2, >=: 2, in: 2]
     end
   end
 
@@ -15,11 +15,13 @@ defmodule Type.Operators do
 
   @doc """
   shortcut for `Type.Union.of/2`
-
-  Note that `|` is a bit of a special form in the parser, and if you try to create a union'd type
-  at the end of a list, you might have a rude surprise.
   """
-  defdelegate a | b, to: Type.Union, as: :of
+  defdelegate a <|> b, to: Type.Union, as: :of
+
+  @doc """
+  shortcut for `Type.intersection/2
+  """
+  defdelegate a <~> b, to: Type, as: :intersection
 
   @doc """
   shortcut for `Type.compare/2`

--- a/lib/type/union.ex
+++ b/lib/type/union.ex
@@ -34,12 +34,8 @@ defmodule Type.Union do
 
   @spec merge([Type.t], Type.t, [Type.t]) :: [Type.t]
   defp merge([top | rest], type, stack) do
-    #top |> IO.inspect(label: "37")
-    #rest  |> IO.inspect(label: "38")
-    #type  |> IO.inspect(label: "39")
-    #stack |> IO.inspect(label: "40")
 
-    with cmp when cmp != :eq <- Type.compare(top, type), #|> IO.inspect(label: "42"),
+    with cmp when cmp != :eq <- Type.compare(top, type),
          {new_type, new_list} <- type_merge(cmp, top, type, rest) do
       merge(new_list, new_type, stack)
     else
@@ -57,10 +53,7 @@ defmodule Type.Union do
 
   @spec type_merge(:gt | :lt, Type.t, Type.t, [Type.t]) :: {Type.t, [Type.t]}
   def type_merge(:gt, top, type, rest) do
-    #type |> IO.inspect(label: "60")
-    #top |> IO.inspect(label: "61")
-    #rest |> IO.inspect(label: "62")
-    type_merge([type | rest], top) #|> IO.inspect(label: "63")
+    type_merge([type | rest], top)
   end
   def type_merge(:lt, top, type, rest) do
     type_merge([top | rest], type)
@@ -72,6 +65,9 @@ defmodule Type.Union do
     {a..b, rest}
   end
   def type_merge([a | rest], b..c) when b == a + 1 do
+    {a..c, rest}
+  end
+  def type_merge([b | rest], a..c) when a <= b and b <= c do
     {a..c, rest}
   end
   def type_merge([a..b | rest], c) when c == b + 1 do

--- a/test/type/builtin/intersection_test.exs
+++ b/test/type/builtin/intersection_test.exs
@@ -44,8 +44,8 @@ defmodule TypeTest.Builtin.IntersectionTest do
     end
 
     test "with unions works as expected" do
-      assert -10..-1 == Type.intersection(builtin(:neg_integer), (-10..10 | 15..16))
-      assert builtin(:none) == Type.intersection(builtin(:neg_integer), (1..10 | 12..16))
+      assert -10..-1 == Type.intersection(builtin(:neg_integer), (-10..10 <|> 15..16))
+      assert builtin(:none) == Type.intersection(builtin(:neg_integer), (1..10 <|> 12..16))
     end
 
     test "with all other types is none" do
@@ -77,8 +77,8 @@ defmodule TypeTest.Builtin.IntersectionTest do
     end
 
     test "with unions works as expected" do
-      assert (1..10 | 15..16) == Type.intersection(builtin(:pos_integer), (-10..10 | 15..16))
-      assert builtin(:none) == Type.intersection(builtin(:pos_integer), (:foo | -42))
+      assert (1..10 <|> 15..16) == Type.intersection(builtin(:pos_integer), (-10..10 <|> 15..16))
+      assert builtin(:none) == Type.intersection(builtin(:pos_integer), (:foo <|> -42))
     end
 
     test "with all other types is none" do
@@ -114,8 +114,8 @@ defmodule TypeTest.Builtin.IntersectionTest do
     end
 
     test "with unions works as expected" do
-      assert (0..10 | 15..16) == Type.intersection(builtin(:non_neg_integer), (-10..10 | 15..16))
-      assert builtin(:none) == Type.intersection(builtin(:non_neg_integer), (:foo | -42))
+      assert (0..10 <|> 15..16) == Type.intersection(builtin(:non_neg_integer), (-10..10 <|> 15..16))
+      assert builtin(:none) == Type.intersection(builtin(:non_neg_integer), (:foo <|> -42))
     end
 
     test "with all other types is none" do
@@ -140,8 +140,8 @@ defmodule TypeTest.Builtin.IntersectionTest do
     end
 
     test "with unions works as expected" do
-      assert (-10..10 | 15..16) == Type.intersection(builtin(:integer), (-10..10 | 15..16))
-      assert builtin(:none) == Type.intersection(builtin(:integer), (:foo | builtin(:pid)))
+      assert (-10..10 <|> 15..16) == Type.intersection(builtin(:integer), (-10..10 <|> 15..16))
+      assert builtin(:none) == Type.intersection(builtin(:integer), (:foo <|> builtin(:pid)))
     end
 
     test "with all other types is none" do
@@ -159,8 +159,8 @@ defmodule TypeTest.Builtin.IntersectionTest do
     end
 
     test "with unions works as expected" do
-      assert builtin(:float) == Type.intersection(builtin(:float), (builtin(:float) | 15..16))
-      assert builtin(:none) == Type.intersection(builtin(:float), (:foo | builtin(:pid)))
+      assert builtin(:float) == Type.intersection(builtin(:float), (builtin(:float) <|> 15..16))
+      assert builtin(:none) == Type.intersection(builtin(:float), (:foo <|> builtin(:pid)))
     end
 
     test "with all other types is none" do
@@ -182,8 +182,8 @@ defmodule TypeTest.Builtin.IntersectionTest do
     end
 
     test "with unions works as expected" do
-      assert :foo == Type.intersection(builtin(:atom), (builtin(:float) | :foo | 10..12))
-      assert builtin(:none) == Type.intersection(builtin(:atom), (builtin(:integer) | builtin(:pid)))
+      assert :foo == Type.intersection(builtin(:atom), (builtin(:float) <|> :foo <|> 10..12))
+      assert builtin(:none) == Type.intersection(builtin(:atom), (builtin(:integer) <|> builtin(:pid)))
     end
 
     test "with all other types is none" do
@@ -201,8 +201,8 @@ defmodule TypeTest.Builtin.IntersectionTest do
     end
 
     test "with unions works as expected" do
-      assert builtin(:reference) == Type.intersection(builtin(:reference), (builtin(:reference) | :foo | 10..12))
-      assert builtin(:none) == Type.intersection(builtin(:reference), (builtin(:integer) | builtin(:pid)))
+      assert builtin(:reference) == Type.intersection(builtin(:reference), (builtin(:reference) <|> :foo <|> 10..12))
+      assert builtin(:none) == Type.intersection(builtin(:reference), (builtin(:integer) <|> builtin(:pid)))
     end
 
     test "with all other types is none" do
@@ -220,8 +220,8 @@ defmodule TypeTest.Builtin.IntersectionTest do
     end
 
     test "with unions works as expected" do
-      assert builtin(:port) == Type.intersection(builtin(:port), (builtin(:port) | :foo | 10..12))
-      assert builtin(:none) == Type.intersection(builtin(:port), (builtin(:integer) | builtin(:pid)))
+      assert builtin(:port) == Type.intersection(builtin(:port), (builtin(:port) <|> :foo <|> 10..12))
+      assert builtin(:none) == Type.intersection(builtin(:port), (builtin(:integer) <|> builtin(:pid)))
     end
 
     test "with all other types is none" do
@@ -239,8 +239,8 @@ defmodule TypeTest.Builtin.IntersectionTest do
     end
 
     test "with unions works as expected" do
-      assert builtin(:pid) == Type.intersection(builtin(:pid), (builtin(:pid) | :foo | 10..12))
-      assert builtin(:none) == Type.intersection(builtin(:pid), (builtin(:integer) | builtin(:port)))
+      assert builtin(:pid) == Type.intersection(builtin(:pid), (builtin(:pid) <|> :foo <|> 10..12))
+      assert builtin(:none) == Type.intersection(builtin(:pid), (builtin(:integer) <|> builtin(:port)))
     end
 
     test "with all other types is none" do

--- a/test/type/builtin/intersection_test.exs
+++ b/test/type/builtin/intersection_test.exs
@@ -10,7 +10,7 @@ defmodule TypeTest.Builtin.IntersectionTest do
     test "with all other types is none" do
       TypeTest.Targets.except()
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(builtin(:none), target)
+        assert builtin(:none) == builtin(:none) <~> target
       end)
     end
   end
@@ -19,236 +19,235 @@ defmodule TypeTest.Builtin.IntersectionTest do
     test "with all other types is itself" do
       TypeTest.Targets.except()
       |> Enum.each(fn target ->
-        assert target == Type.intersection(builtin(:any), target)
+        assert target == builtin(:any) <~> target
       end)
     end
   end
 
   describe "the intersection of neg_integer" do
     test "with any, integer, and neg_integer is itself" do
-      assert builtin(:neg_integer) == Type.intersection(builtin(:neg_integer), builtin(:any))
-      assert builtin(:neg_integer) == Type.intersection(builtin(:neg_integer), builtin(:integer))
-      assert builtin(:neg_integer) == Type.intersection(builtin(:neg_integer), builtin(:neg_integer))
+      assert builtin(:neg_integer) == builtin(:neg_integer) <~> builtin(:any)
+      assert builtin(:neg_integer) == builtin(:neg_integer) <~> builtin(:integer)
+      assert builtin(:neg_integer) == builtin(:neg_integer) <~> builtin(:neg_integer)
     end
 
     test "with integers yields the integer only for negative integers" do
-      assert -47 == Type.intersection(builtin(:neg_integer), -47)
-      assert builtin(:none) == Type.intersection(builtin(:neg_integer), 47)
+      assert -47 == builtin(:neg_integer) <~> -47
+      assert builtin(:none) == builtin(:neg_integer) <~> 47
     end
 
     test "with ranges trim as expected" do
-      assert -47..-1        == Type.intersection(builtin(:neg_integer), -47..-1)
-      assert -47..-1        == Type.intersection(builtin(:neg_integer), -47..47)
-      assert -1             == Type.intersection(builtin(:neg_integer), -1..47)
-      assert builtin(:none) == Type.intersection(builtin(:neg_integer), 1..47)
+      assert -47..-1        == builtin(:neg_integer) <~> -47..-1
+      assert -47..-1        == builtin(:neg_integer) <~> -47..47
+      assert -1             == builtin(:neg_integer) <~> -1..47
+      assert builtin(:none) == builtin(:neg_integer) <~> 1..47
     end
 
     test "with unions works as expected" do
-      assert -10..-1 == Type.intersection(builtin(:neg_integer), (-10..10 <|> 15..16))
-      assert builtin(:none) == Type.intersection(builtin(:neg_integer), (1..10 <|> 12..16))
+      assert -10..-1 == builtin(:neg_integer) <~> (-10..10 <|> 15..16)
+      assert builtin(:none) == builtin(:neg_integer) <~> (1..10 <|> 12..16)
     end
 
     test "with all other types is none" do
       TypeTest.Targets.except([-47, builtin(:neg_integer), builtin(:integer), -10..10])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(builtin(:neg_integer), target)
+        assert builtin(:none) == builtin(:neg_integer) <~> target
       end)
     end
   end
 
   describe "the intersection of pos_integer" do
     test "with any, integer, and pos_integer, and non_neg_integer is itself" do
-      assert builtin(:pos_integer) == Type.intersection(builtin(:pos_integer), builtin(:any))
-      assert builtin(:pos_integer) == Type.intersection(builtin(:pos_integer), builtin(:integer))
-      assert builtin(:pos_integer) == Type.intersection(builtin(:pos_integer), builtin(:non_neg_integer))
-      assert builtin(:pos_integer) == Type.intersection(builtin(:pos_integer), builtin(:pos_integer))
+      assert builtin(:pos_integer) == builtin(:pos_integer) <~> builtin(:any)
+      assert builtin(:pos_integer) == builtin(:pos_integer) <~> builtin(:integer)
+      assert builtin(:pos_integer) == builtin(:pos_integer) <~> builtin(:non_neg_integer)
+      assert builtin(:pos_integer) == builtin(:pos_integer) <~> builtin(:pos_integer)
     end
 
     test "with integers yields the integer only for negative integers" do
-      assert 47 == Type.intersection(builtin(:pos_integer), 47)
-      assert builtin(:none) == Type.intersection(builtin(:pos_integer), -47)
+      assert 47 == builtin(:pos_integer) <~> 47
+      assert builtin(:none) == builtin(:pos_integer) <~> -47
     end
 
     test "with ranges trim as expected" do
-      assert 1..47          == Type.intersection(builtin(:pos_integer), 1..47)
-      assert 1..47          == Type.intersection(builtin(:pos_integer), -47..47)
-      assert 1              == Type.intersection(builtin(:pos_integer), -47..1)
-      assert builtin(:none) == Type.intersection(builtin(:pos_integer), -47..-1)
+      assert 1..47          == builtin(:pos_integer) <~> 1..47
+      assert 1..47          == builtin(:pos_integer) <~> -47..47
+      assert 1              == builtin(:pos_integer) <~> -47..1
+      assert builtin(:none) == builtin(:pos_integer) <~> -47..-1
     end
 
     test "with unions works as expected" do
-      assert (1..10 <|> 15..16) == Type.intersection(builtin(:pos_integer), (-10..10 <|> 15..16))
-      assert builtin(:none) == Type.intersection(builtin(:pos_integer), (:foo <|> -42))
+      assert (1..10 <|> 15..16) == builtin(:pos_integer) <~> (-10..10 <|> 15..16)
+      assert builtin(:none) == builtin(:pos_integer) <~> (:foo <|> -42)
     end
 
     test "with all other types is none" do
       TypeTest.Targets.except([47, builtin(:pos_integer), builtin(:non_neg_integer), builtin(:integer), -10..10])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(builtin(:pos_integer), target)
+        assert builtin(:none) == builtin(:pos_integer) <~> target
       end)
     end
   end
 
   describe "the intersection of non_neg_integer" do
     test "with any, integer, and non_neg_integer is itself" do
-      assert builtin(:non_neg_integer) == Type.intersection(builtin(:non_neg_integer), builtin(:any))
-      assert builtin(:non_neg_integer) == Type.intersection(builtin(:non_neg_integer), builtin(:integer))
-      assert builtin(:non_neg_integer) == Type.intersection(builtin(:non_neg_integer), builtin(:non_neg_integer))
+      assert builtin(:non_neg_integer) == builtin(:non_neg_integer) <~> builtin(:any)
+      assert builtin(:non_neg_integer) == builtin(:non_neg_integer) <~> builtin(:integer)
+      assert builtin(:non_neg_integer) == builtin(:non_neg_integer) <~> builtin(:non_neg_integer)
     end
 
     test "with pos_integer is pos_integer" do
-      assert builtin(:pos_integer) == Type.intersection(builtin(:non_neg_integer), builtin(:pos_integer))
+      assert builtin(:pos_integer) == builtin(:non_neg_integer) <~> builtin(:pos_integer)
     end
 
     test "with integers yields the integer only for negative integers" do
-      assert 47 == Type.intersection(builtin(:non_neg_integer), 47)
-      assert 0 == Type.intersection(builtin(:non_neg_integer), 0)
-      assert builtin(:none) == Type.intersection(builtin(:non_neg_integer), -47)
+      assert 47 == builtin(:non_neg_integer) <~> 47
+      assert 0 == builtin(:non_neg_integer) <~> 0
+      assert builtin(:none) == builtin(:non_neg_integer) <~> -47
     end
 
     test "with ranges trim as expected" do
-      assert 0..47          == Type.intersection(builtin(:non_neg_integer), 0..47)
-      assert 0..47          == Type.intersection(builtin(:non_neg_integer), -47..47)
-      assert 0              == Type.intersection(builtin(:non_neg_integer), -47..0)
-      assert builtin(:none) == Type.intersection(builtin(:non_neg_integer), -47..-1)
+      assert 0..47          == builtin(:non_neg_integer) <~> 0..47
+      assert 0..47          == builtin(:non_neg_integer) <~> -47..47
+      assert 0              == builtin(:non_neg_integer) <~> -47..0
+      assert builtin(:none) == builtin(:non_neg_integer) <~> -47..-1
     end
 
     test "with unions works as expected" do
-      assert (0..10 <|> 15..16) == Type.intersection(builtin(:non_neg_integer), (-10..10 <|> 15..16))
-      assert builtin(:none) == Type.intersection(builtin(:non_neg_integer), (:foo <|> -42))
+      assert (0..10 <|> 15..16) == builtin(:non_neg_integer) <~> (-10..10 <|> 15..16)
+      assert builtin(:none) == builtin(:non_neg_integer) <~> (:foo <|> -42)
     end
 
     test "with all other types is none" do
       TypeTest.Targets.except([0, 47, builtin(:pos_integer), builtin(:non_neg_integer), builtin(:integer), -10..10])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(builtin(:non_neg_integer), target)
+        assert builtin(:none) == builtin(:non_neg_integer) <~> target
       end)
     end
   end
 
   describe "the intersection of integer" do
     test "with any, integer is itself" do
-      assert builtin(:integer) == Type.intersection(builtin(:integer), builtin(:any))
-      assert builtin(:integer) == Type.intersection(builtin(:integer), builtin(:integer))
+      assert builtin(:integer) == builtin(:integer) <~> builtin(:any)
+      assert builtin(:integer) == builtin(:integer) <~> builtin(:integer)
     end
 
     test "with integer subtypes is themselves" do
       [47, -47..47, builtin(:neg_integer), builtin(:pos_integer), builtin(:non_neg_integer)]
       |> Enum.each(fn type ->
-        assert type == Type.intersection(builtin(:integer), type)
+        assert type == builtin(:integer) <~> type
       end)
     end
 
     test "with unions works as expected" do
-      assert (-10..10 <|> 15..16) == Type.intersection(builtin(:integer), (-10..10 <|> 15..16))
-      assert builtin(:none) == Type.intersection(builtin(:integer), (:foo <|> builtin(:pid)))
+      assert (-10..10 <|> 15..16) == builtin(:integer) <~> (-10..10 <|> 15..16)
+      assert builtin(:none) == builtin(:integer) <~> (:foo <|> builtin(:pid))
     end
 
     test "with all other types is none" do
       TypeTest.Targets.except([-47, 0, 47, builtin(:neg_integer), builtin(:pos_integer), builtin(:non_neg_integer), builtin(:integer), -10..10])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(builtin(:integer), target)
+        assert builtin(:none) == builtin(:integer) <~> target
       end)
     end
   end
 
   describe "the intersection of float" do
     test "with any, float is itself" do
-      assert builtin(:float) == Type.intersection(builtin(:float), builtin(:any))
-      assert builtin(:float) == Type.intersection(builtin(:float), builtin(:float))
+      assert builtin(:float) == builtin(:float) <~> builtin(:any)
+      assert builtin(:float) == builtin(:float) <~> builtin(:float)
     end
 
     test "with unions works as expected" do
-      assert builtin(:float) == Type.intersection(builtin(:float), (builtin(:float) <|> 15..16))
-      assert builtin(:none) == Type.intersection(builtin(:float), (:foo <|> builtin(:pid)))
+      assert builtin(:float) == builtin(:float) <~> (builtin(:float) <|> 15..16)
+      assert builtin(:none) == builtin(:float) <~> (:foo <|> builtin(:pid))
     end
 
     test "with all other types is none" do
       TypeTest.Targets.except([builtin(:float)])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(builtin(:float), target)
+        assert builtin(:none) == builtin(:float) <~> target
       end)
     end
   end
 
   describe "the intersection of atom" do
     test "with any, atom is itself" do
-      assert builtin(:atom) == Type.intersection(builtin(:atom), builtin(:any))
-      assert builtin(:atom) == Type.intersection(builtin(:atom), builtin(:atom))
+      assert builtin(:atom) == builtin(:atom) <~> builtin(:any)
+      assert builtin(:atom) == builtin(:atom) <~> builtin(:atom)
     end
 
     test "with an actual atom is the atom" do
-      assert :foo == Type.intersection(builtin(:atom), :foo)
+      assert :foo == builtin(:atom) <~> :foo
     end
 
     test "with unions works as expected" do
-      assert :foo == Type.intersection(builtin(:atom), (builtin(:float) <|> :foo <|> 10..12))
-      assert builtin(:none) == Type.intersection(builtin(:atom), (builtin(:integer) <|> builtin(:pid)))
+      assert :foo == builtin(:atom) <~> (builtin(:float) <|> :foo <|> 10..12)
+      assert builtin(:none) == builtin(:atom) <~> (builtin(:integer) <|> builtin(:pid))
     end
 
     test "with all other types is none" do
       TypeTest.Targets.except([:foo, builtin(:atom)])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(builtin(:atom), target)
+        assert builtin(:none) == builtin(:atom) <~> target
       end)
     end
   end
 
   describe "the intersection of reference" do
     test "with any, reference is itself" do
-      assert builtin(:reference) == Type.intersection(builtin(:reference), builtin(:any))
-      assert builtin(:reference) == Type.intersection(builtin(:reference), builtin(:reference))
+      assert builtin(:reference) == builtin(:reference) <~> builtin(:any)
+      assert builtin(:reference) == builtin(:reference) <~> builtin(:reference)
     end
 
     test "with unions works as expected" do
-      assert builtin(:reference) == Type.intersection(builtin(:reference), (builtin(:reference) <|> :foo <|> 10..12))
-      assert builtin(:none) == Type.intersection(builtin(:reference), (builtin(:integer) <|> builtin(:pid)))
+      assert builtin(:reference) == builtin(:reference) <~> (builtin(:reference) <|> :foo <|> 10..12)
+      assert builtin(:none) == builtin(:reference) <~> (builtin(:integer) <|> builtin(:pid))
     end
 
     test "with all other types is none" do
       TypeTest.Targets.except([builtin(:reference)])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(builtin(:reference), target)
+        assert builtin(:none) == builtin(:reference) <~> target
       end)
     end
   end
 
   describe "the intersection of port" do
     test "with any, port is itself" do
-      assert builtin(:port) == Type.intersection(builtin(:port), builtin(:any))
-      assert builtin(:port) == Type.intersection(builtin(:port), builtin(:port))
+      assert builtin(:port) == builtin(:port) <~> builtin(:any)
+      assert builtin(:port) == builtin(:port) <~> builtin(:port)
     end
 
     test "with unions works as expected" do
-      assert builtin(:port) == Type.intersection(builtin(:port), (builtin(:port) <|> :foo <|> 10..12))
-      assert builtin(:none) == Type.intersection(builtin(:port), (builtin(:integer) <|> builtin(:pid)))
+      assert builtin(:port) == builtin(:port) <~> (builtin(:port) <|> :foo <|> 10..12)
+      assert builtin(:none) == builtin(:port) <~> (builtin(:integer) <|> builtin(:pid))
     end
 
     test "with all other types is none" do
       TypeTest.Targets.except([builtin(:port)])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(builtin(:port), target)
+        assert builtin(:none) == builtin(:port) <~> target
       end)
     end
   end
 
   describe "the intersection of pid" do
     test "with any, pid is itself" do
-      assert builtin(:pid) == Type.intersection(builtin(:pid), builtin(:any))
-      assert builtin(:pid) == Type.intersection(builtin(:pid), builtin(:pid))
+      assert builtin(:pid) == builtin(:pid) <~> builtin(:any)
+      assert builtin(:pid) == builtin(:pid) <~> builtin(:pid)
     end
 
     test "with unions works as expected" do
-      assert builtin(:pid) == Type.intersection(builtin(:pid), (builtin(:pid) <|> :foo <|> 10..12))
-      assert builtin(:none) == Type.intersection(builtin(:pid), (builtin(:integer) <|> builtin(:port)))
+      assert builtin(:pid) == builtin(:pid) <~> (builtin(:pid) <|> :foo <|> 10..12)
+      assert builtin(:none) == builtin(:pid) <~> (builtin(:integer) <|> builtin(:port))
     end
 
     test "with all other types is none" do
       TypeTest.Targets.except([builtin(:pid)])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(builtin(:pid), target)
+        assert builtin(:none) == builtin(:pid) <~> target
       end)
     end
   end
-
 end

--- a/test/type/builtin/subtype_test.exs
+++ b/test/type/builtin/subtype_test.exs
@@ -17,7 +17,7 @@ defmodule TypeTest.Builtin.SubtypeTest do
     end
 
     test "is a subtype of a union with itself" do
-      assert builtin(:none) in (builtin(:none) | builtin(:integer))
+      assert builtin(:none) in (builtin(:none) <|> builtin(:integer))
     end
 
     test "is not a subtype of all types" do
@@ -39,13 +39,13 @@ defmodule TypeTest.Builtin.SubtypeTest do
     end
 
     test "is a subtype of unions with itself and integer" do
-      assert builtin(:neg_integer) in (builtin(:neg_integer) | builtin(:atom))
-      assert builtin(:neg_integer) in (builtin(:integer) | builtin(:atom))
+      assert builtin(:neg_integer) in (builtin(:neg_integer) <|> builtin(:atom))
+      assert builtin(:neg_integer) in (builtin(:integer) <|> builtin(:atom))
     end
 
     test "is not a subtype of orthogonal unions" do
-      refute builtin(:neg_integer) in (builtin(:pid) | builtin(:atom))
-      refute builtin(:neg_integer) in (builtin(:pid) | builtin(:atom))
+      refute builtin(:neg_integer) in (builtin(:pid) <|> builtin(:atom))
+      refute builtin(:neg_integer) in (builtin(:pid) <|> builtin(:atom))
     end
 
     test "is not a subtype of all types" do
@@ -68,14 +68,14 @@ defmodule TypeTest.Builtin.SubtypeTest do
     end
 
     test "is a subtype of unions with itself and integer" do
-      assert builtin(:pos_integer) in (builtin(:pos_integer) | builtin(:atom))
-      assert builtin(:pos_integer) in (builtin(:non_neg_integer) | builtin(:atom))
-      assert builtin(:pos_integer) in (builtin(:integer) | builtin(:atom))
+      assert builtin(:pos_integer) in (builtin(:pos_integer) <|> builtin(:atom))
+      assert builtin(:pos_integer) in (builtin(:non_neg_integer) <|> builtin(:atom))
+      assert builtin(:pos_integer) in (builtin(:integer) <|> builtin(:atom))
     end
 
     test "is not a subtype of orthogonal unions" do
-      refute builtin(:pos_integer) in (builtin(:pid) | builtin(:atom))
-      refute builtin(:pos_integer) in (builtin(:pid) | builtin(:atom))
+      refute builtin(:pos_integer) in (builtin(:pid) <|> builtin(:atom))
+      refute builtin(:pos_integer) in (builtin(:pid) <|> builtin(:atom))
     end
 
     test "is not a subtype of all types" do
@@ -97,13 +97,13 @@ defmodule TypeTest.Builtin.SubtypeTest do
     end
 
     test "is a subtype of unions with itself and integer" do
-      assert builtin(:non_neg_integer) in (builtin(:non_neg_integer) | builtin(:atom))
-      assert builtin(:non_neg_integer) in (builtin(:integer) | builtin(:atom))
+      assert builtin(:non_neg_integer) in (builtin(:non_neg_integer) <|> builtin(:atom))
+      assert builtin(:non_neg_integer) in (builtin(:integer) <|> builtin(:atom))
     end
 
     test "is not a subtype of orthogonal unions" do
-      refute builtin(:non_neg_integer) in (builtin(:pid) | builtin(:atom))
-      refute builtin(:non_neg_integer) in (builtin(:pid) | builtin(:atom))
+      refute builtin(:non_neg_integer) in (builtin(:pid) <|> builtin(:atom))
+      refute builtin(:non_neg_integer) in (builtin(:pid) <|> builtin(:atom))
     end
 
     test "is not a subtype of all types" do
@@ -125,11 +125,11 @@ defmodule TypeTest.Builtin.SubtypeTest do
     end
 
     test "is a subtype of unions with itself" do
-      assert builtin(:integer) in (builtin(:integer) | builtin(:atom))
+      assert builtin(:integer) in (builtin(:integer) <|> builtin(:atom))
     end
 
     test "is not a subtype of orthogonal unions" do
-      refute builtin(:integer) in (builtin(:pid) | builtin(:atom))
+      refute builtin(:integer) in (builtin(:pid) <|> builtin(:atom))
     end
 
     test "is not a subtype of all other types" do
@@ -151,11 +151,11 @@ defmodule TypeTest.Builtin.SubtypeTest do
     end
 
     test "is a subtype of unions with itself" do
-      assert builtin(:float) in (builtin(:float) | builtin(:atom))
+      assert builtin(:float) in (builtin(:float) <|> builtin(:atom))
     end
 
     test "is not a subtype of orthogonal unions" do
-      refute builtin(:float) in (builtin(:pid) | builtin(:atom))
+      refute builtin(:float) in (builtin(:pid) <|> builtin(:atom))
     end
 
     test "is not a subtype of all other types" do
@@ -177,11 +177,11 @@ defmodule TypeTest.Builtin.SubtypeTest do
     end
 
     test "is a subtype of unions with itself" do
-      assert builtin(:atom) in (builtin(:integer) | builtin(:atom))
+      assert builtin(:atom) in (builtin(:integer) <|> builtin(:atom))
     end
 
     test "is not a subtype of orthogonal unions" do
-      refute builtin(:atom) in (builtin(:pid) | builtin(:integer))
+      refute builtin(:atom) in (builtin(:pid) <|> builtin(:integer))
     end
 
     test "is not a subtype of all other types" do
@@ -203,11 +203,11 @@ defmodule TypeTest.Builtin.SubtypeTest do
     end
 
     test "is a subtype of unions with itself" do
-      assert builtin(:reference) in (builtin(:reference) | builtin(:atom))
+      assert builtin(:reference) in (builtin(:reference) <|> builtin(:atom))
     end
 
     test "is not a subtype of orthogonal unions" do
-      refute builtin(:reference) in (builtin(:pid) | builtin(:atom))
+      refute builtin(:reference) in (builtin(:pid) <|> builtin(:atom))
     end
 
     test "is not a subtype of all other types" do
@@ -229,11 +229,11 @@ defmodule TypeTest.Builtin.SubtypeTest do
     end
 
     test "is a subtype of unions with itself" do
-      assert builtin(:port) in (builtin(:port) | builtin(:atom))
+      assert builtin(:port) in (builtin(:port) <|> builtin(:atom))
     end
 
     test "is not a subtype of orthogonal unions" do
-      refute builtin(:port) in (builtin(:pid) | builtin(:atom))
+      refute builtin(:port) in (builtin(:pid) <|> builtin(:atom))
     end
 
     test "is not a subtype of all other types" do
@@ -255,11 +255,11 @@ defmodule TypeTest.Builtin.SubtypeTest do
     end
 
     test "is a subtype of unions with itself" do
-      assert builtin(:pid) in (builtin(:pid) | builtin(:atom))
+      assert builtin(:pid) in (builtin(:pid) <|> builtin(:atom))
     end
 
     test "is not a subtype of orthogonal unions" do
-      refute builtin(:pid) in (builtin(:integer) | builtin(:atom))
+      refute builtin(:pid) in (builtin(:integer) <|> builtin(:atom))
     end
 
     test "is not a subtype of all other types" do

--- a/test/type/builtin/usable_as_test.exs
+++ b/test/type/builtin/usable_as_test.exs
@@ -26,9 +26,9 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "is usable as a union with self, integer and any" do
-      assert :ok = builtin(:neg_integer) ~> (builtin(:neg_integer) | builtin(:atom))
-      assert :ok = builtin(:neg_integer) ~> (builtin(:integer) | builtin(:atom))
-      assert :ok = builtin(:neg_integer) ~> (builtin(:any) | builtin(:atom))
+      assert :ok = builtin(:neg_integer) ~> (builtin(:neg_integer) <|> builtin(:atom))
+      assert :ok = builtin(:neg_integer) ~> (builtin(:integer) <|> builtin(:atom))
+      assert :ok = builtin(:neg_integer) ~> (builtin(:any) <|> builtin(:atom))
     end
 
     test "could be usable as a negative number, partially negative range" do
@@ -41,7 +41,7 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "might be usable as a union with a range" do
-      assert {:maybe, _} = builtin(:neg_integer) ~> (-10..-1 | :pos_integer)
+      assert {:maybe, _} = builtin(:neg_integer) ~> (-10..-1 <|> :pos_integer)
     end
 
     test "cannot be usable as a non-negative number, or positive range" do
@@ -52,7 +52,7 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "is not usable as a union of disjoint types" do
-      assert {:error, _} = builtin(:neg_integer) ~> (builtin(:pos_integer) | builtin(:atom))
+      assert {:error, _} = builtin(:neg_integer) ~> (builtin(:pos_integer) <|> builtin(:atom))
     end
 
     test "cannot generally be used as incompatible types" do
@@ -73,9 +73,9 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "is usable as a union with self, integer and any" do
-      assert :ok = builtin(:non_neg_integer) ~> (builtin(:non_neg_integer) | builtin(:atom))
-      assert :ok = builtin(:non_neg_integer) ~> (builtin(:integer) | builtin(:atom))
-      assert :ok = builtin(:non_neg_integer) ~> (builtin(:any) | builtin(:atom))
+      assert :ok = builtin(:non_neg_integer) ~> (builtin(:non_neg_integer) <|> builtin(:atom))
+      assert :ok = builtin(:non_neg_integer) ~> (builtin(:integer) <|> builtin(:atom))
+      assert :ok = builtin(:non_neg_integer) ~> (builtin(:any) <|> builtin(:atom))
     end
 
     test "could be usable as a non negative number, positive number, partially non negative range" do
@@ -92,7 +92,7 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "might be usable as a union with a range" do
-      assert {:maybe, _} = builtin(:non_neg_integer) ~> (1..10 | :neg_integer)
+      assert {:maybe, _} = builtin(:non_neg_integer) ~> (1..10 <|> :neg_integer)
     end
 
     test "cannot be usable as a negative number, or negative range" do
@@ -103,7 +103,7 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "is not usable as a union of disjoint types" do
-      assert {:error, _} = builtin(:non_neg_integer) ~> (builtin(:neg_integer) | builtin(:atom))
+      assert {:error, _} = builtin(:non_neg_integer) ~> (builtin(:neg_integer) <|> builtin(:atom))
     end
 
     test "cannot generally be used as incompatible types" do
@@ -126,9 +126,9 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "is usable as a union with self, integer and any" do
-      assert :ok = builtin(:pos_integer) ~> (builtin(:pos_integer) | builtin(:atom))
-      assert :ok = builtin(:pos_integer) ~> (builtin(:integer) | builtin(:atom))
-      assert :ok = builtin(:pos_integer) ~> (builtin(:any) | builtin(:atom))
+      assert :ok = builtin(:pos_integer) ~> (builtin(:pos_integer) <|> builtin(:atom))
+      assert :ok = builtin(:pos_integer) ~> (builtin(:integer) <|> builtin(:atom))
+      assert :ok = builtin(:pos_integer) ~> (builtin(:any) <|> builtin(:atom))
     end
 
     test "could be usable as a positive number, partially positive range" do
@@ -141,7 +141,7 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "might be usable as a union with a range" do
-      assert {:maybe, _} = builtin(:pos_integer) ~> (1..10 | :neg_integer)
+      assert {:maybe, _} = builtin(:pos_integer) ~> (1..10 <|> :neg_integer)
     end
 
     test "cannot be usable as a negative number, negative range" do
@@ -154,7 +154,7 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "is not usable as a union of disjoint types" do
-      assert {:error, _} = builtin(:pos_integer) ~> (builtin(:neg_integer) | builtin(:atom))
+      assert {:error, _} = builtin(:pos_integer) ~> (builtin(:neg_integer) <|> builtin(:atom))
     end
 
     test "cannot generally be used as incompatible types" do
@@ -175,8 +175,8 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "is usable as a union with self and any" do
-      assert :ok = builtin(:integer) ~> (builtin(:integer) | builtin(:atom))
-      assert :ok = builtin(:integer) ~> (builtin(:any) | builtin(:atom))
+      assert :ok = builtin(:integer) ~> (builtin(:integer) <|> builtin(:atom))
+      assert :ok = builtin(:integer) ~> (builtin(:any) <|> builtin(:atom))
     end
 
     test "could be usable as a number, or range" do
@@ -196,7 +196,7 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "is not usable as a union of disjoint types" do
-      assert {:error, _} = builtin(:integer) ~> (builtin(:float) | builtin(:atom))
+      assert {:error, _} = builtin(:integer) ~> (builtin(:float) <|> builtin(:atom))
     end
 
     test "cannot generally be used as incompatible types" do
@@ -217,12 +217,12 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "is usable as a union with self and any" do
-      assert :ok = builtin(:float) ~> (builtin(:float) | builtin(:atom))
-      assert :ok = builtin(:float) ~> (builtin(:any) | builtin(:atom))
+      assert :ok = builtin(:float) ~> (builtin(:float) <|> builtin(:atom))
+      assert :ok = builtin(:float) ~> (builtin(:any) <|> builtin(:atom))
     end
 
     test "is not usable as a union of disjoint types" do
-      assert {:error, _} = builtin(:float) ~> (builtin(:pid) | builtin(:atom))
+      assert {:error, _} = builtin(:float) ~> (builtin(:pid) <|> builtin(:atom))
     end
 
     test "cannot generally be used as incompatible types" do
@@ -242,8 +242,8 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "is usable as a union with self and any" do
-      assert :ok = builtin(:atom) ~> (builtin(:atom) | builtin(:integer))
-      assert :ok = builtin(:atom) ~> (builtin(:any) | builtin(:integer))
+      assert :ok = builtin(:atom) ~> (builtin(:atom) <|> builtin(:integer))
+      assert :ok = builtin(:atom) ~> (builtin(:any) <|> builtin(:integer))
     end
 
     test "might be usable as an atom literal" do
@@ -252,7 +252,7 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "is not usable as a union of disjoint types" do
-      assert {:error, _} = builtin(:atom) ~> (builtin(:float) | builtin(:integer))
+      assert {:error, _} = builtin(:atom) ~> (builtin(:float) <|> builtin(:integer))
     end
 
     test "cannot generally be used as incompatible types" do
@@ -272,12 +272,12 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "is usable as a union with self and any" do
-      assert :ok = builtin(:reference) ~> (builtin(:reference) | builtin(:atom))
-      assert :ok = builtin(:reference) ~> (builtin(:any) | builtin(:atom))
+      assert :ok = builtin(:reference) ~> (builtin(:reference) <|> builtin(:atom))
+      assert :ok = builtin(:reference) ~> (builtin(:any) <|> builtin(:atom))
     end
 
     test "is not usable as a union of disjoint types" do
-      assert {:error, _} = builtin(:reference) ~> (builtin(:atom) | builtin(:pid))
+      assert {:error, _} = builtin(:reference) ~> (builtin(:atom) <|> builtin(:pid))
     end
 
     test "cannot generally be used as incompatible types" do
@@ -297,7 +297,7 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "is not usable as a union of disjoint types" do
-      assert {:error, _} = builtin(:port) ~> (builtin(:atom) | builtin(:pid))
+      assert {:error, _} = builtin(:port) ~> (builtin(:atom) <|> builtin(:pid))
     end
 
     test "cannot generally be used as incompatible types" do
@@ -317,12 +317,12 @@ defmodule TypeTest.Builtin.UsableAsTest do
     end
 
     test "is usable as a union with self and any" do
-      assert :ok = builtin(:pid) ~> (builtin(:pid) | builtin(:atom))
-      assert :ok = builtin(:pid) ~> (builtin(:any) | builtin(:atom))
+      assert :ok = builtin(:pid) ~> (builtin(:pid) <|> builtin(:atom))
+      assert :ok = builtin(:pid) ~> (builtin(:any) <|> builtin(:atom))
     end
 
     test "is not usable as a union of disjoint types" do
-      assert {:error, _} = builtin(:pid) ~> (builtin(:atom) | builtin(:reference))
+      assert {:error, _} = builtin(:pid) ~> (builtin(:atom) <|> builtin(:reference))
     end
 
     test "cannot generally be used as incompatible types" do

--- a/test/type/fetch_type/atoms_test.exs
+++ b/test/type/fetch_type/atoms_test.exs
@@ -17,7 +17,7 @@ defmodule TypeTest.Type.FetchType.AtomsTest do
   end
 
   test "boolean" do
-    assert {:ok, (true | false)} == Type.fetch_type(@source, :boolean_type)
+    assert {:ok, (true <|> false)} == Type.fetch_type(@source, :boolean_type)
   end
 
   test "module" do

--- a/test/type/fetch_type/basics_test.exs
+++ b/test/type/fetch_type/basics_test.exs
@@ -33,7 +33,7 @@ defmodule TypeTest.Type.FetchType.BasicsTest do
   end
 
   test "identifier is a union of pid, port, and reference" do
-    assert {:ok, (builtin(:pid) | builtin(:port) | builtin(:reference))} ==
+    assert {:ok, (builtin(:pid) <|> builtin(:port) <|> builtin(:reference))} ==
       Type.fetch_type(@source, :identifier_type)
   end
 

--- a/test/type/fetch_type/bitstrings_test copy.exs
+++ b/test/type/fetch_type/bitstrings_test copy.exs
@@ -35,7 +35,7 @@ defmodule TypeTest.Type.FetchType.BitstringsTest do
   end
 
   test "iodata/0" do
-    assert {:ok, (%Bitstring{size: 0, unit: 8} | builtin(:iolist))} == Type.fetch_type(@source, :iodata_type)
+    assert {:ok, (%Bitstring{size: 0, unit: 8} <|> builtin(:iolist))} == Type.fetch_type(@source, :iodata_type)
   end
 
   test "iolist/0" do

--- a/test/type/fetch_type/etc_test.exs
+++ b/test/type/fetch_type/etc_test.exs
@@ -12,7 +12,7 @@ defmodule TypeTest.Type.FetchType.EtcTest do
   @remote TypeTest.TypeExample.Remote
 
   test "union (of atoms)" do
-    assert {:ok, (:foo | :bar)} == Type.fetch_type(@unions, :of_atoms)
+    assert {:ok, (:foo <|> :bar)} == Type.fetch_type(@unions, :of_atoms)
   end
 
   describe "remote type" do

--- a/test/type/fetch_type/lists_test.exs
+++ b/test/type/fetch_type/lists_test.exs
@@ -35,7 +35,7 @@ defmodule TypeTest.Type.FetchType.ListsTest do
   end
 
   test "keyword/2 literal list" do
-    keyword_type = (%Type.Tuple{elements: [:foo, builtin(:integer)]} | %Type.Tuple{elements: [:bar, builtin(:float)]})
+    keyword_type = (%Type.Tuple{elements: [:foo, builtin(:integer)]} <|> %Type.Tuple{elements: [:bar, builtin(:float)]})
     assert {:ok, %List{type: keyword_type}} ==
       Type.fetch_type(@source, :keyword_2_literal)
   end
@@ -56,7 +56,7 @@ defmodule TypeTest.Type.FetchType.ListsTest do
   end
 
   test "maybe_improper_list/2" do
-    assert {:ok, %List{type: builtin(:integer), final: (nil | [])}} ==
+    assert {:ok, %List{type: builtin(:integer), final: (nil <|> [])}} ==
       Type.fetch_type(@source, :maybe_improper_list_2)
   end
 
@@ -66,7 +66,7 @@ defmodule TypeTest.Type.FetchType.ListsTest do
   end
 
   test "nonempty_maybe_improper_list/2" do
-    assert {:ok, %List{type: builtin(:integer), nonempty: true, final: (nil | [])}} ==
+    assert {:ok, %List{type: builtin(:integer), nonempty: true, final: (nil <|> [])}} ==
       Type.fetch_type(@source, :nonempty_maybe_improper_list_2)
   end
 

--- a/test/type/fetch_type/numbers_test.exs
+++ b/test/type/fetch_type/numbers_test.exs
@@ -36,12 +36,12 @@ defmodule TypeTest.Type.FetchType.NumbersTest do
   end
 
   test "number" do
-    assert {:ok, (builtin(:float) | builtin(:integer))} ==
+    assert {:ok, (builtin(:float) <|> builtin(:integer))} ==
       Type.fetch_type(@source, :number_type)
   end
 
   test "timeout" do
-    assert {:ok, (builtin(:non_neg_integer) | :infinity)} ==
+    assert {:ok, (builtin(:non_neg_integer) <|> :infinity)} ==
       Type.fetch_type(@source, :timeout_type)
   end
 end

--- a/test/type/literal_atom/intersection_test.exs
+++ b/test/type/literal_atom/intersection_test.exs
@@ -8,28 +8,28 @@ defmodule TypeTest.LiteralAtom.IntersectionTest do
 
   describe "the intersection of a literal atom" do
     test "with itself, atoms, and any is itself" do
-      assert :foo == Type.intersection(:foo, builtin(:any))
-      assert :foo == Type.intersection(:foo, builtin(:atom))
-      assert :foo == Type.intersection(:foo, :foo)
+      assert :foo == :foo <~> builtin(:any)
+      assert :foo == :foo <~> builtin(:atom)
+      assert :foo == :foo <~> :foo
     end
 
     test "with other atoms is none" do
-      assert builtin(:none) == Type.intersection(:foo, :bar)
+      assert builtin(:none) == :foo <~> :bar
     end
 
     test "with unions works as expected" do
-      assert :foo == Type.intersection(:foo, (builtin(:atom) <|> builtin(:integer)))
-      assert builtin(:none) == Type.intersection(:foo, (builtin(:integer) <|> builtin(:port)))
+      assert :foo == :foo <~> (builtin(:atom) <|> builtin(:integer))
+      assert builtin(:none) == :foo <~> (builtin(:integer) <|> builtin(:port))
     end
 
     test "with the none type is none" do
-      assert builtin(:none) == Type.intersection(:foo, builtin(:none))
+      assert builtin(:none) == :foo <~> builtin(:none)
     end
 
     test "with all other types is none" do
       TypeTest.Targets.except([:foo, builtin(:atom)])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(:foo, target)
+        assert builtin(:none) == :foo <~> target
       end)
     end
   end

--- a/test/type/literal_atom/intersection_test.exs
+++ b/test/type/literal_atom/intersection_test.exs
@@ -18,8 +18,8 @@ defmodule TypeTest.LiteralAtom.IntersectionTest do
     end
 
     test "with unions works as expected" do
-      assert :foo == Type.intersection(:foo, (builtin(:atom) | builtin(:integer)))
-      assert builtin(:none) == Type.intersection(:foo, (builtin(:integer) | builtin(:port)))
+      assert :foo == Type.intersection(:foo, (builtin(:atom) <|> builtin(:integer)))
+      assert builtin(:none) == Type.intersection(:foo, (builtin(:integer) <|> builtin(:port)))
     end
 
     test "with the none type is none" do

--- a/test/type/literal_atom/subtype_test.exs
+++ b/test/type/literal_atom/subtype_test.exs
@@ -21,13 +21,13 @@ defmodule TypeTest.LiteralAtom.SubtypeTest do
     end
 
     test "is a subtype of a union with itself or atom" do
-      assert :foo in (:foo | :bar)
-      assert :foo in (:foo | builtin(:integer))
-      assert :foo in (builtin(:atom) | builtin(:integer))
+      assert :foo in (:foo <|> :bar)
+      assert :foo in (:foo <|> builtin(:integer))
+      assert :foo in (builtin(:atom) <|> builtin(:integer))
     end
 
     test "is not a subtype of a union with orthogonal types" do
-      refute :foo in (builtin(:integer) | :infinity)
+      refute :foo in (builtin(:integer) <|> :infinity)
     end
 
     test "is not a subtype of other atoms" do

--- a/test/type/literal_atom/usable_as_test.exs
+++ b/test/type/literal_atom/usable_as_test.exs
@@ -17,8 +17,8 @@ defmodule TypeTest.LiteralAtom.UsableAsTest do
     end
 
     test "a union with atoms" do
-      assert (:foo ~> (:foo | 1..47)) == :ok
-      assert (:foo ~> (builtin(:atom) | 47)) == :ok
+      assert (:foo ~> (:foo <|> 1..47)) == :ok
+      assert (:foo ~> (builtin(:atom) <|> 47)) == :ok
     end
 
     test "any" do
@@ -31,7 +31,7 @@ defmodule TypeTest.LiteralAtom.UsableAsTest do
 
   describe "atoms not usable as" do
     test "a union without atoms" do
-      assert {:error, _} = (:foo ~> (builtin(:integer) | builtin(:float)))
+      assert {:error, _} = (:foo ~> (builtin(:integer) <|> builtin(:float)))
     end
 
     test "any other type" do

--- a/test/type/literal_emptylist/intersection_test.exs
+++ b/test/type/literal_emptylist/intersection_test.exs
@@ -22,8 +22,8 @@ defmodule TypeTest.LiteralEmptyList.IntersectionTest do
     end
 
     test "with unions works as expected" do
-      assert [] == Type.intersection([], ([] | builtin(:integer)))
-      assert builtin(:none) == Type.intersection([], (builtin(:integer) | builtin(:port)))
+      assert [] == Type.intersection([], ([] <|> builtin(:integer)))
+      assert builtin(:none) == Type.intersection([], (builtin(:integer) <|> builtin(:port)))
     end
 
     test "with all other types is none" do

--- a/test/type/literal_emptylist/intersection_test.exs
+++ b/test/type/literal_emptylist/intersection_test.exs
@@ -10,26 +10,26 @@ defmodule TypeTest.LiteralEmptyList.IntersectionTest do
 
   describe "the intersection of a literal empty list" do
     test "with itself, general lists and any is itself" do
-      assert [] == Type.intersection([], builtin(:any))
-      assert [] == Type.intersection([], %List{type: :foo})
-      assert [] == Type.intersection([], %List{})
-      assert [] == Type.intersection([], [])
+      assert [] == [] <~> builtin(:any)
+      assert [] == [] <~> %List{type: :foo}
+      assert [] == [] <~> %List{}
+      assert [] == [] <~> []
     end
 
     test "with nonempty, or odd-termination final lists is not ok" do
-      assert builtin(:none) == Type.intersection([], %List{final: :foo})
-      assert builtin(:none) == Type.intersection([], %List{nonempty: true})
+      assert builtin(:none) == [] <~> %List{final: :foo}
+      assert builtin(:none) == [] <~> %List{nonempty: true}
     end
 
     test "with unions works as expected" do
-      assert [] == Type.intersection([], ([] <|> builtin(:integer)))
-      assert builtin(:none) == Type.intersection([], (builtin(:integer) <|> builtin(:port)))
+      assert [] == [] <~> ([] <|> builtin(:integer))
+      assert builtin(:none) == [] <~> (builtin(:integer) <|> builtin(:port))
     end
 
     test "with all other types is none" do
       TypeTest.Targets.except([[], %Type.List{}])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection([], target)
+        assert builtin(:none) == [] <~> target
       end)
     end
   end

--- a/test/type/literal_emptylist/subtype_test.exs
+++ b/test/type/literal_emptylist/subtype_test.exs
@@ -23,12 +23,12 @@ defmodule TypeTest.LiteralEmptylist.SubtypeTest do
     end
 
     test "is a subtype of a union with itself or generic list type" do
-      assert [] in ([] | builtin(:atom))
-      assert [] in (%List{} | builtin(:integer))
+      assert [] in ([] <|> builtin(:atom))
+      assert [] in (%List{} <|> builtin(:integer))
     end
 
     test "is not a subtype of a union with orthogonal types" do
-      refute [] in (%List{nonempty: true} | :infinity)
+      refute [] in (%List{nonempty: true} <|> :infinity)
     end
 
     test "is not a subtype of nonempty lists or list with different finals" do

--- a/test/type/literal_emptylist/usable_as_test.exs
+++ b/test/type/literal_emptylist/usable_as_test.exs
@@ -20,8 +20,8 @@ defmodule TypeTest.LiteralEmptyList.UsableAsTest do
     end
 
     test "a union with list" do
-      assert ([] ~> ([] | builtin(:atom))) == :ok
-      assert ([] ~> (%List{} | builtin(:atom))) == :ok
+      assert ([] ~> ([] <|> builtin(:atom))) == :ok
+      assert ([] ~> (%List{} <|> builtin(:atom))) == :ok
     end
 
     test "any" do
@@ -42,7 +42,7 @@ defmodule TypeTest.LiteralEmptyList.UsableAsTest do
     end
 
     test "a union without list" do
-      assert {:error, _} = ([] ~> (builtin(:integer) | builtin(:float)))
+      assert {:error, _} = ([] ~> (builtin(:integer) <|> builtin(:float)))
     end
 
     test "any other type" do

--- a/test/type/literal_integer/intersection_test.exs
+++ b/test/type/literal_integer/intersection_test.exs
@@ -33,8 +33,8 @@ defmodule TypeTest.LiteralInteger.IntersectionTest do
     end
 
     test "with unions works as expected" do
-      assert 47 == Type.intersection(47, (builtin(:integer) | :infinity))
-      assert builtin(:none) == Type.intersection(47, (builtin(:atom) | builtin(:port)))
+      assert 47 == Type.intersection(47, (builtin(:integer) <|> :infinity))
+      assert builtin(:none) == Type.intersection(47, (builtin(:atom) <|> builtin(:port)))
     end
 
     test "with all other types is none" do

--- a/test/type/literal_integer/intersection_test.exs
+++ b/test/type/literal_integer/intersection_test.exs
@@ -8,39 +8,39 @@ defmodule TypeTest.LiteralInteger.IntersectionTest do
 
   describe "the intersection of a literal integer" do
     test "with itself, integer and any is itself" do
-      assert 47 == Type.intersection(47, builtin(:any))
-      assert 47 == Type.intersection(47, builtin(:integer))
-      assert 47 == Type.intersection(47, 47)
+      assert 47 == 47 <~> builtin(:any)
+      assert 47 == 47 <~> builtin(:integer)
+      assert 47 == 47 <~> 47
     end
 
     test "with integer types is correct" do
-      assert -47 == Type.intersection(-47, builtin(:neg_integer))
-      assert builtin(:none) == Type.intersection(-47, builtin(:pos_integer))
-      assert builtin(:none) == Type.intersection(-47, builtin(:non_neg_integer))
+      assert -47 == -47 <~> builtin(:neg_integer)
+      assert builtin(:none) == -47 <~> builtin(:pos_integer)
+      assert builtin(:none) == -47 <~> builtin(:non_neg_integer)
 
-      assert builtin(:none) == Type.intersection(0, builtin(:neg_integer))
-      assert builtin(:none) == Type.intersection(0, builtin(:pos_integer))
-      assert 0 == Type.intersection(0, builtin(:non_neg_integer))
+      assert builtin(:none) == 0 <~> builtin(:neg_integer)
+      assert builtin(:none) == 0 <~> builtin(:pos_integer)
+      assert 0 == 0 <~> builtin(:non_neg_integer)
 
-      assert builtin(:none) == Type.intersection(47, builtin(:neg_integer))
-      assert 47 == Type.intersection(47, builtin(:pos_integer))
-      assert 47 == Type.intersection(47, builtin(:non_neg_integer))
+      assert builtin(:none) == 47 <~> builtin(:neg_integer)
+      assert 47 == 47 <~> builtin(:pos_integer)
+      assert 47 == 47 <~> builtin(:non_neg_integer)
     end
 
     test "with ranges is correct" do
-      assert 47 == Type.intersection(47, 0..50)
-      assert builtin(:none) == Type.intersection(42, 0..10)
+      assert 47 == 47 <~> 0..50
+      assert builtin(:none) == 42 <~> 0..10
     end
 
     test "with unions works as expected" do
-      assert 47 == Type.intersection(47, (builtin(:integer) <|> :infinity))
-      assert builtin(:none) == Type.intersection(47, (builtin(:atom) <|> builtin(:port)))
+      assert 47 == 47 <~> (builtin(:integer) <|> :infinity)
+      assert builtin(:none) == 47 <~> (builtin(:atom) <|> builtin(:port))
     end
 
     test "with all other types is none" do
       TypeTest.Targets.except([builtin(:integer), builtin(:pos_integer), builtin(:non_neg_integer)])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(42, target)
+        assert builtin(:none) == 42 <~> target
       end)
     end
   end

--- a/test/type/literal_integer/subtype_test.exs
+++ b/test/type/literal_integer/subtype_test.exs
@@ -38,13 +38,13 @@ defmodule TypeTest.LiteralInteger.SubtypeTest do
     end
 
     test "is a subtype of a union with itself or integer types" do
-      assert -47 in (-47 | builtin(:atom))
-      assert -47 in (builtin(:neg_integer) | builtin(:atom))
-      assert -47 in (builtin(:integer) | builtin(:atom))
+      assert -47 in (-47 <|> builtin(:atom))
+      assert -47 in (builtin(:neg_integer) <|> builtin(:atom))
+      assert -47 in (builtin(:integer) <|> builtin(:atom))
     end
 
     test "is not a subtype of a union with orthogonal types" do
-      refute -47 in (builtin(:pos_integer) | :infinity)
+      refute -47 in (builtin(:pos_integer) <|> :infinity)
     end
 
     test "is not a subtype of other types" do
@@ -61,13 +61,13 @@ defmodule TypeTest.LiteralInteger.SubtypeTest do
     end
 
     test "is a subtype of a union with itself or integer types" do
-      assert 0 in (0 | builtin(:atom))
-      assert 0 in (builtin(:non_neg_integer) | builtin(:atom))
-      assert 0 in (builtin(:integer) | builtin(:atom))
+      assert 0 in (0 <|> builtin(:atom))
+      assert 0 in (builtin(:non_neg_integer) <|> builtin(:atom))
+      assert 0 in (builtin(:integer) <|> builtin(:atom))
     end
 
     test "is not a subtype of a union with orthogonal types" do
-      refute 0 in (builtin(:pos_integer) | :infinity)
+      refute 0 in (builtin(:pos_integer) <|> :infinity)
     end
 
     test "is not a subtype of wrong integer classes" do
@@ -83,14 +83,14 @@ defmodule TypeTest.LiteralInteger.SubtypeTest do
     end
 
     test "is a subtype of a union with itself or integer types" do
-      assert 47 in (47 | builtin(:atom))
-      assert 47 in (builtin(:non_neg_integer) | builtin(:atom))
-      assert 47 in (builtin(:pos_integer) | builtin(:atom))
-      assert 47 in (builtin(:integer) | builtin(:atom))
+      assert 47 in (47 <|> builtin(:atom))
+      assert 47 in (builtin(:non_neg_integer) <|> builtin(:atom))
+      assert 47 in (builtin(:pos_integer) <|> builtin(:atom))
+      assert 47 in (builtin(:integer) <|> builtin(:atom))
     end
 
     test "is not a subtype of a union with orthogonal types" do
-      refute 47 in (builtin(:neg_integer) | :infinity)
+      refute 47 in (builtin(:neg_integer) <|> :infinity)
     end
 
     test "is not a subtype of wrong integer classes" do

--- a/test/type/literal_integer/usable_as_test.exs
+++ b/test/type/literal_integer/usable_as_test.exs
@@ -27,9 +27,9 @@ defmodule TypeTest.LiteralInteger.UsableAsTest do
     end
 
     test "a union with the appropriate category" do
-      assert 47 ~> (builtin(:pos_integer) | :infinity) == :ok
-      assert 47 ~> (builtin(:non_neg_integer) | :infinity) == :ok
-      assert 47 ~> (builtin(:integer) | :infinity) == :ok
+      assert 47 ~> (builtin(:pos_integer) <|> :infinity) == :ok
+      assert 47 ~> (builtin(:non_neg_integer) <|> :infinity) == :ok
+      assert 47 ~> (builtin(:integer) <|> :infinity) == :ok
     end
 
     test "any" do
@@ -61,7 +61,7 @@ defmodule TypeTest.LiteralInteger.UsableAsTest do
     end
 
     test "a union with the noninclusive categories" do
-      assert {:error, _} = -47 ~> (builtin(:pos_integer) | :infinity)
+      assert {:error, _} = -47 ~> (builtin(:pos_integer) <|> :infinity)
     end
 
     test "any other type" do

--- a/test/type/literal_range/intersection_test.exs
+++ b/test/type/literal_range/intersection_test.exs
@@ -70,8 +70,8 @@ defmodule TypeTest.LiteralRange.IntersectionTest do
     end
 
     test "with unions works as expected" do
-      assert (1 | 9..10) == Type.intersection(1..10, (0..1 | 9..15))
-      assert builtin(:none) == Type.intersection(1..10, (builtin(:atom) | builtin(:port)))
+      assert (1 <|> 9..10) == Type.intersection(1..10, (0..1 <|> 9..15))
+      assert builtin(:none) == Type.intersection(1..10, (builtin(:atom) <|> builtin(:port)))
     end
 
     test "with all other types is none" do

--- a/test/type/literal_range/intersection_test.exs
+++ b/test/type/literal_range/intersection_test.exs
@@ -8,76 +8,76 @@ defmodule TypeTest.LiteralRange.IntersectionTest do
 
   describe "the intersection of a literal range" do
     test "with itself, integer and any is itself" do
-      assert -47..47 == Type.intersection(-47..47, builtin(:any))
-      assert -47..47 == Type.intersection(-47..47, builtin(:integer))
-      assert -47..47 == Type.intersection(-47..47, -47..47)
+      assert -47..47 == -47..47 <~> builtin(:any)
+      assert -47..47 == -47..47 <~> builtin(:integer)
+      assert -47..47 == -47..47 <~> -47..47
     end
 
     test "with integer subsets" do
       # negative ranges
-      assert -47..-1        == Type.intersection(-47..-1, builtin(:neg_integer))
-      assert builtin(:none) == Type.intersection(-47..-1, builtin(:pos_integer))
-      assert builtin(:none) == Type.intersection(-47..-1, builtin(:non_neg_integer))
+      assert -47..-1        == -47..-1 <~> builtin(:neg_integer)
+      assert builtin(:none) == -47..-1 <~> builtin(:pos_integer)
+      assert builtin(:none) == -47..-1 <~> builtin(:non_neg_integer)
 
       # straddling ranges
-      assert -47..-1 == Type.intersection(-47..47, builtin(:neg_integer))
-      assert -1      == Type.intersection(-1..1, builtin(:neg_integer))
-      assert 1..47   == Type.intersection(-47..47, builtin(:pos_integer))
-      assert 1       == Type.intersection(-1..1, builtin(:pos_integer))
-      assert 0..47   == Type.intersection(-47..47, builtin(:non_neg_integer))
-      assert 0       == Type.intersection(-1..0, builtin(:non_neg_integer))
+      assert -47..-1 == -47..47 <~> builtin(:neg_integer)
+      assert -1      == -1..1 <~> builtin(:neg_integer)
+      assert 1..47   == -47..47 <~> builtin(:pos_integer)
+      assert 1       == -1..1 <~> builtin(:pos_integer)
+      assert 0..47   == -47..47 <~> builtin(:non_neg_integer)
+      assert 0       == -1..0 <~> builtin(:non_neg_integer)
 
       # positive ranges
-      assert builtin(:none) == Type.intersection(1..47, builtin(:neg_integer))
-      assert 1..47          == Type.intersection(1..47, builtin(:pos_integer))
-      assert 1..47          == Type.intersection(1..47, builtin(:non_neg_integer))
+      assert builtin(:none) == 1..47 <~> builtin(:neg_integer)
+      assert 1..47          == 1..47 <~> builtin(:pos_integer)
+      assert 1..47          == 1..47 <~> builtin(:non_neg_integer)
     end
 
     test "with other ranges" do
       # disjoint left
-      assert builtin(:none) == Type.intersection(1..10, 11..12)
+      assert builtin(:none) == 1..10 <~> 11..12
       # overlapping left
-      assert 10             == Type.intersection(1..10, 10..12)
-      assert 9..10          == Type.intersection(1..10, 9..12)
+      assert 10             == 1..10 <~> 10..12
+      assert 9..10          == 1..10 <~> 9..12
       # internal left
-      assert 1..10          == Type.intersection(1..10, 1..12)
+      assert 1..10          == 1..10 <~> 1..12
       # internal center
-      assert 1..10          == Type.intersection(1..10, 0..12)
+      assert 1..10          == 1..10 <~> 0..12
       # internal right
-      assert 1..10          == Type.intersection(1..10, 0..10)
+      assert 1..10          == 1..10 <~> 0..10
       # overlapping right
-      assert 1..2           == Type.intersection(1..10, 0..2)
-      assert 1              == Type.intersection(1..10, 0..1)
+      assert 1..2           == 1..10 <~> 0..2
+      assert 1              == 1..10 <~> 0..1
       #disjoint right
-      assert builtin(:none) == Type.intersection(1..10, -1..0)
+      assert builtin(:none) == 1..10 <~> -1..0
 
       # symmetrical to above
-      assert builtin(:none) == Type.intersection(11..12, 1..10)
-      assert 10             == Type.intersection(10..12, 1..10)
-      assert 9..10          == Type.intersection(9..12,  1..10)
-      assert 1..10          == Type.intersection(1..12,  1..10)
-      assert 1..10          == Type.intersection(0..12,  1..10)
-      assert 1..10          == Type.intersection(0..10,  1..10)
-      assert 1..2           == Type.intersection(0..2,   1..10)
-      assert 1              == Type.intersection(0..1,   1..10)
-      assert builtin(:none) == Type.intersection(-1..0,  1..10)
+      assert builtin(:none) == 11..12 <~> 1..10
+      assert 10             == 10..12 <~> 1..10
+      assert 9..10          == 9..12 <~>  1..10
+      assert 1..10          == 1..12 <~>  1..10
+      assert 1..10          == 0..12 <~>  1..10
+      assert 1..10          == 0..10 <~>  1..10
+      assert 1..2           == 0..2 <~>   1..10
+      assert 1              == 0..1 <~>   1..10
+      assert builtin(:none) == -1..0 <~>  1..10
     end
 
     test "with integers" do
-      assert builtin(:none) == Type.intersection(1..10, -42)
-      assert 47 == Type.intersection(0..255, 47)
-      assert builtin(:none) == Type.intersection(1..10, 42)
+      assert builtin(:none) == 1..10 <~> -42
+      assert 47 == 0..255 <~> 47
+      assert builtin(:none) == 1..10 <~> 42
     end
 
     test "with unions works as expected" do
-      assert (1 <|> 9..10) == Type.intersection(1..10, (0..1 <|> 9..15))
-      assert builtin(:none) == Type.intersection(1..10, (builtin(:atom) <|> builtin(:port)))
+      assert (1 <|> 9..10) == 1..10 <~> (0..1 <|> 9..15)
+      assert builtin(:none) == 1..10 <~> (builtin(:atom) <|> builtin(:port))
     end
 
     test "with all other types is none" do
       TypeTest.Targets.except([-10..10, builtin(:pos_integer), builtin(:non_neg_integer), builtin(:integer)])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(1..10, target)
+        assert builtin(:none) == 1..10 <~> target
       end)
     end
   end

--- a/test/type/literal_range/subtype_test.exs
+++ b/test/type/literal_range/subtype_test.exs
@@ -37,14 +37,14 @@ defmodule TypeTest.LiteralRange.SubtypeTest do
     end
 
     test "is a subtype of unions with ranges and integer classes" do
-      assert -47..-1 in (-47..-1 | builtin(:atom))
-      assert -47..-1 in (-50..-1 | builtin(:atom))
-      assert -47..-1 in (builtin(:neg_integer) | builtin(:atom))
-      assert -47..-1 in (builtin(:integer) | builtin(:atom))
+      assert -47..-1 in (-47..-1 <|> builtin(:atom))
+      assert -47..-1 in (-50..-1 <|> builtin(:atom))
+      assert -47..-1 in (builtin(:neg_integer) <|> builtin(:atom))
+      assert -47..-1 in (builtin(:integer) <|> builtin(:atom))
     end
 
     test "is not a subtype of orthogonal types" do
-      refute -47..-1 in (builtin(:pos_integer) | builtin(:atom))
+      refute -47..-1 in (builtin(:pos_integer) <|> builtin(:atom))
     end
 
     test "is not a subtype of other types" do
@@ -62,8 +62,8 @@ defmodule TypeTest.LiteralRange.SubtypeTest do
     end
 
     test "is a subtype of a strategic partial" do
-      assert -10..0 in (-10..-1 | builtin(:non_neg_integer))
-      assert -1..0 in (-1 | builtin(:non_neg_integer))
+      assert -10..0 in (-10..-1 <|> builtin(:non_neg_integer))
+      assert -1..0 in (-1 <|> builtin(:non_neg_integer))
     end
 
     test "is not a subtype of any of the integer classes" do
@@ -80,8 +80,8 @@ defmodule TypeTest.LiteralRange.SubtypeTest do
     end
 
     test "is a subtype of strategic partials" do
-      assert -10..10 in (-10..-1 | builtin(:non_neg_integer))
-      assert -1..128 in (-1 | builtin(:non_neg_integer))
+      assert -10..10 in (-10..-1 <|> builtin(:non_neg_integer))
+      assert -1..128 in (-1 <|> builtin(:non_neg_integer))
     end
 
     test "is not a subtype of any of the integer classes" do
@@ -99,13 +99,13 @@ defmodule TypeTest.LiteralRange.SubtypeTest do
     end
 
     test "is a subtype of correct integer classes" do
-      assert 0..42 in (builtin(:non_neg_integer) | builtin(:atom))
-      assert 0..42 in (builtin(:integer) | builtin(:atom))
+      assert 0..42 in (builtin(:non_neg_integer) <|> builtin(:atom))
+      assert 0..42 in (builtin(:integer) <|> builtin(:atom))
     end
 
     test "is not a subtype of orthogonal types" do
-      refute 0..42 in (builtin(:neg_integer) | builtin(:atom))
-      refute 0..42 in (builtin(:pos_integer) | builtin(:atom))
+      refute 0..42 in (builtin(:neg_integer) <|> builtin(:atom))
+      refute 0..42 in (builtin(:pos_integer) <|> builtin(:atom))
     end
 
     test "is not a subtype of some integer classes" do
@@ -123,13 +123,13 @@ defmodule TypeTest.LiteralRange.SubtypeTest do
     end
 
     test "is a subtype of correct integer classes" do
-      assert 1..47 in (builtin(:pos_integer) | builtin(:atom))
-      assert 1..47 in (builtin(:non_neg_integer) | builtin(:atom))
-      assert 1..47 in (builtin(:integer) | builtin(:atom))
+      assert 1..47 in (builtin(:pos_integer) <|> builtin(:atom))
+      assert 1..47 in (builtin(:non_neg_integer) <|> builtin(:atom))
+      assert 1..47 in (builtin(:integer) <|> builtin(:atom))
     end
 
     test "is not a subtype of orthogonal types" do
-      refute 1..47 in (builtin(:neg_integer) | builtin(:atom))
+      refute 1..47 in (builtin(:neg_integer) <|> builtin(:atom))
     end
 
     test "is not a subtype of some integer classes" do

--- a/test/type/literal_range/usable_as_test.exs
+++ b/test/type/literal_range/usable_as_test.exs
@@ -26,16 +26,16 @@ defmodule TypeTest.LiteralRange.UsableAsTest do
     end
 
     test "stitched ranges" do
-      assert (-10..10 ~> (-10..-1 | builtin(:non_neg_integer))) == :ok
-      assert (-10..10 ~> (builtin(:neg_integer) | 0..10)) == :ok
-      assert (-10..0 ~> (builtin(:neg_integer) | 0)) == :ok
-      assert (-1..10 ~> (-1 | builtin(:non_neg_integer))) == :ok
+      assert (-10..10 ~> (-10..-1 <|> builtin(:non_neg_integer))) == :ok
+      assert (-10..10 ~> (builtin(:neg_integer) <|> 0..10)) == :ok
+      assert (-10..0 ~> (builtin(:neg_integer) <|> 0)) == :ok
+      assert (-1..10 ~> (-1 <|> builtin(:non_neg_integer))) == :ok
     end
 
     test "a union with the appropriate category" do
-      assert 1..47 ~> (builtin(:pos_integer) | :infinity) == :ok
-      assert 1..47 ~> (builtin(:non_neg_integer) | :infinity) == :ok
-      assert 1..47 ~> (builtin(:integer) | :infinity) == :ok
+      assert 1..47 ~> (builtin(:pos_integer) <|> :infinity) == :ok
+      assert 1..47 ~> (builtin(:non_neg_integer) <|> :infinity) == :ok
+      assert 1..47 ~> (builtin(:integer) <|> :infinity) == :ok
     end
 
     test "any" do
@@ -74,7 +74,7 @@ defmodule TypeTest.LiteralRange.UsableAsTest do
     end
 
     test "a union with a partially overlapping category" do
-      assert {:maybe, _} = 1..47 ~> (1..10 | :infinity)
+      assert {:maybe, _} = 1..47 ~> (1..10 <|> :infinity)
     end
   end
 
@@ -98,7 +98,7 @@ defmodule TypeTest.LiteralRange.UsableAsTest do
     end
 
     test "a union with a disjoint categories" do
-      assert {:error, _} = 1..47 ~> (builtin(:atom) | builtin(:pid))
+      assert {:error, _} = 1..47 ~> (builtin(:atom) <|> builtin(:pid))
     end
 
     test "any other type" do

--- a/test/type/operators_test.exs
+++ b/test/type/operators_test.exs
@@ -10,8 +10,8 @@ defmodule TypeTest.OperatorsTest do
     assert (:foo ~> builtin(:atom)) == :ok
   end
 
-  test "|/2 is the type union operator" do
-    assert :foo | :bar == %Type.Union{of: [:bar, :foo]}
+  test "<|>/2 is the type union operator" do
+    assert :foo <|> :bar == %Type.Union{of: [:foo, :bar]}
   end
 
   test "ordering operators work as erlang terms" do

--- a/test/type/type_bitstring/intersection_test.exs
+++ b/test/type/type_bitstring/intersection_test.exs
@@ -65,8 +65,8 @@ defmodule TypeTest.TypeBitstring.IntersectionTest do
     end
 
     test "with unions" do
-      assert @basic_binary == Type.intersection(@basic_binary, (@basic_bitstring | builtin(:atom)))
-      assert builtin(:none) == Type.intersection(@basic_binary, (builtin(:atom) | builtin(:port)))
+      assert @basic_binary == Type.intersection(@basic_binary, (@basic_bitstring <|> builtin(:atom)))
+      assert builtin(:none) == Type.intersection(@basic_binary, (builtin(:atom) <|> builtin(:port)))
     end
   end
 end

--- a/test/type/type_bitstring/intersection_test.exs
+++ b/test/type/type_bitstring/intersection_test.exs
@@ -14,59 +14,59 @@ defmodule TypeTest.TypeBitstring.IntersectionTest do
 
   describe "the intersection of empty bitstring" do
     test "with itself, integer and any is itself" do
-      assert @empty_bitstring == Type.intersection(@empty_bitstring, builtin(:any))
-      assert @empty_bitstring == Type.intersection(@empty_bitstring, @empty_bitstring)
+      assert @empty_bitstring == @empty_bitstring <~> builtin(:any)
+      assert @empty_bitstring == @empty_bitstring <~> @empty_bitstring
     end
 
     test "with any string with size 0 is itself" do
-      assert @empty_bitstring == Type.intersection(@empty_bitstring, @basic_bitstring)
-      assert @empty_bitstring == Type.intersection(@empty_bitstring, @basic_binary)
+      assert @empty_bitstring == @empty_bitstring <~> @basic_bitstring
+      assert @empty_bitstring == @empty_bitstring <~> @basic_binary
     end
 
     test "with any fixed size string is none" do
-      assert builtin(:none) == Type.intersection(@empty_bitstring, %Bitstring{size: 8, unit: 0})
-      assert builtin(:none) == Type.intersection(@empty_bitstring, %Bitstring{size: 8, unit: 8})
+      assert builtin(:none) == @empty_bitstring <~> %Bitstring{size: 8, unit: 0}
+      assert builtin(:none) == @empty_bitstring <~> %Bitstring{size: 8, unit: 8}
     end
 
     test "with all other types is none" do
       TypeTest.Targets.except([@empty_bitstring])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(@empty_bitstring, target)
+        assert builtin(:none) == @empty_bitstring <~> target
       end)
     end
   end
 
   describe "the intersection of basic bitstring" do
     test "with itself, integer and any is itself" do
-      assert @basic_bitstring == Type.intersection(@basic_bitstring, builtin(:any))
-      assert @basic_bitstring == Type.intersection(@basic_bitstring, @basic_bitstring)
+      assert @basic_bitstring == @basic_bitstring <~> builtin(:any)
+      assert @basic_bitstring == @basic_bitstring <~> @basic_bitstring
     end
 
     test "with any string with size 1 is the more specific size" do
-      assert @basic_binary                == Type.intersection(@basic_bitstring, @basic_binary)
-      assert %Bitstring{size: 0, unit: 3} == Type.intersection(@basic_bitstring, %Bitstring{size: 0, unit: 3})
+      assert @basic_binary                == @basic_bitstring <~> @basic_binary
+      assert %Bitstring{size: 0, unit: 3} == @basic_bitstring <~> %Bitstring{size: 0, unit: 3}
     end
 
     test "with any fixed size string is the fixed size string" do
-      assert %Bitstring{size: 8, unit: 0} == Type.intersection(@basic_bitstring, %Bitstring{size: 8, unit: 0})
-      assert %Bitstring{size: 8, unit: 8} == Type.intersection(@basic_bitstring, %Bitstring{size: 8, unit: 8})
+      assert %Bitstring{size: 8, unit: 0} == @basic_bitstring <~> %Bitstring{size: 8, unit: 0}
+      assert %Bitstring{size: 8, unit: 8} == @basic_bitstring <~> %Bitstring{size: 8, unit: 8}
     end
   end
 
   describe "other combinations" do
     test "disparate unit sizes" do
-      assert %Bitstring{size: 0, unit: 24} == Type.intersection(@basic_binary, %Bitstring{size: 0, unit: 3})
-      assert %Bitstring{size: 0, unit: 24} == Type.intersection(@basic_binary, %Bitstring{size: 0, unit: 6})
+      assert %Bitstring{size: 0, unit: 24} == @basic_binary <~> %Bitstring{size: 0, unit: 3}
+      assert %Bitstring{size: 0, unit: 24} == @basic_binary <~> %Bitstring{size: 0, unit: 6}
     end
 
     test "different offsets" do
       assert %Bitstring{size: 15, unit: 8} ==
-        Type.intersection(%Bitstring{size: 7, unit: 8}, %Bitstring{size: 15, unit: 8})
+        %Bitstring{size: 7, unit: 8} <~> %Bitstring{size: 15, unit: 8}
     end
 
     test "with unions" do
-      assert @basic_binary == Type.intersection(@basic_binary, (@basic_bitstring <|> builtin(:atom)))
-      assert builtin(:none) == Type.intersection(@basic_binary, (builtin(:atom) <|> builtin(:port)))
+      assert @basic_binary == @basic_binary <~> (@basic_bitstring <|> builtin(:atom))
+      assert builtin(:none) == @basic_binary <~> (builtin(:atom) <|> builtin(:port))
     end
   end
 end

--- a/test/type/type_bitstring/subtype_test.exs
+++ b/test/type/type_bitstring/subtype_test.exs
@@ -25,13 +25,13 @@ defmodule TypeTest.TypeBitstring.SubtypeTest do
     end
 
     test "is a subtype of appropriate unions" do
-      assert @empty_bitstring in (@empty_bitstring | builtin(:atom))
-      assert @empty_bitstring in (@basic_bitstring | builtin(:atom))
-      assert @empty_bitstring in (@basic_binary | builtin(:atom))
+      assert @empty_bitstring in (@empty_bitstring <|> builtin(:atom))
+      assert @empty_bitstring in (@basic_bitstring <|> builtin(:atom))
+      assert @empty_bitstring in (@basic_binary <|> builtin(:atom))
     end
 
     test "is not a subtype of orthogonal types" do
-      refute @empty_bitstring in (builtin(:atom) | builtin(:integer))
+      refute @empty_bitstring in (builtin(:atom) <|> builtin(:integer))
     end
 
     test "is not a subtype of any bitstring that has size" do

--- a/test/type/type_bitstring/usable_as_test.exs
+++ b/test/type/type_bitstring/usable_as_test.exs
@@ -111,11 +111,11 @@ defmodule TypeTest.TypeBitString.UsableAsTest do
   end
 
   test "bitstrings are usable as unions including their supertype" do
-    assert :ok = %Bitstring{size: 16, unit: 8} ~> (%Bitstring{size: 0, unit: 8} | builtin(:atom))
+    assert :ok = %Bitstring{size: 16, unit: 8} ~> (%Bitstring{size: 0, unit: 8} <|> builtin(:atom))
   end
 
   test "bitstrings are not usable as disjoint unions" do
-    assert {:error, _} = %Bitstring{size: 16, unit: 8} ~> (builtin(:pid) | builtin(:atom))
+    assert {:error, _} = %Bitstring{size: 16, unit: 8} ~> (builtin(:pid) <|> builtin(:atom))
   end
 
   test "bitstrings generally are not usable as other types" do

--- a/test/type/type_function/intersection_test.exs
+++ b/test/type/type_function/intersection_test.exs
@@ -15,39 +15,39 @@ defmodule TypeTest.TypeFunction.IntersectionTest do
 
   describe "the any function" do
     test "intersects with any and self" do
-      assert @any_function == Type.intersection(@any_function, @any)
-      assert @any_function == Type.intersection(@any, @any_function)
+      assert @any_function == @any_function <~> @any
+      assert @any_function == @any <~> @any_function
 
-      assert @any_function == Type.intersection(@any_function, @any_function)
+      assert @any_function == @any_function <~> @any_function
     end
 
     test "matches the arity of parameters" do
       # zero arity
-      assert @zero_arity_any == Type.intersection(@any_function, @zero_arity_any)
+      assert @zero_arity_any == @any_function <~> @zero_arity_any
       # one arity
-      assert @one_arity_any == Type.intersection(@any_function, @one_arity_any)
+      assert @one_arity_any == @any_function <~> @one_arity_any
       # two arity
-      assert @two_arity_any == Type.intersection(@any_function, @two_arity_any)
+      assert @two_arity_any == @any_function <~> @two_arity_any
 
       # arbitrary params
       assert %Function{params: [builtin(:integer)], return: @any} ==
-        Type.intersection(@any_function, %Function{params: [builtin(:integer)], return: @any})
+        @any_function <~> %Function{params: [builtin(:integer)], return: @any}
     end
 
     test "reduces return" do
       assert %Function{params: :any, return: builtin(:integer)} ==
-        Type.intersection(@any_function, %Function{params: :any, return: builtin(:integer)})
+        @any_function <~> %Function{params: :any, return: builtin(:integer)}
     end
 
     test "reduces both" do
       assert %Function{params: [builtin(:integer)], return: builtin(:integer)} ==
-        Type.intersection(@any_function, %Function{params: [builtin(:integer)], return: builtin(:integer)})
+        @any_function <~> %Function{params: [builtin(:integer)], return: builtin(:integer)}
     end
 
     test "intersects with nothing else" do
       TypeTest.Targets.except([%Function{params: [], return: 0}])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(@any_function, target)
+        assert builtin(:none) == @any_function <~> target
       end)
     end
   end
@@ -55,107 +55,107 @@ defmodule TypeTest.TypeFunction.IntersectionTest do
   describe "a function with any parameters" do
     @any_with_integer %Function{params: :any, return: builtin(:integer)}
     test "intersects with self and the any function" do
-      assert @any_with_integer == Type.intersection(@any_with_integer, @any_with_integer)
-      assert @any_with_integer == Type.intersection(@any_with_integer, @any_function)
+      assert @any_with_integer == @any_with_integer <~> @any_with_integer
+      assert @any_with_integer == @any_with_integer <~> @any_function
     end
 
     test "matches the arity of parameters" do
       # zero arity
       assert %Function{params: [], return: builtin(:integer)} ==
-          Type.intersection(@any_with_integer, @zero_arity_any)
+          @any_with_integer <~> @zero_arity_any
       # one arity
       assert %Function{params: [@any], return: builtin(:integer)} ==
-          Type.intersection(@any_with_integer, @one_arity_any)
+          @any_with_integer <~> @one_arity_any
       # two arity
       assert %Function{params: [@any, @any], return: builtin(:integer)} ==
-          Type.intersection(@any_with_integer, @two_arity_any)
+          @any_with_integer <~> @two_arity_any
 
       # arbitrary params
       assert %Function{params: [builtin(:integer)], return: builtin(:integer)} ==
-        Type.intersection(@any_with_integer, %Function{params: [builtin(:integer)], return: @any})
+        @any_with_integer <~> %Function{params: [builtin(:integer)], return: @any}
     end
 
     test "reduces return" do
       assert %Function{params: :any, return: 1..10} ==
-        Type.intersection(@any_with_integer, %Function{params: :any, return: 1..10})
+        @any_with_integer <~> %Function{params: :any, return: 1..10}
     end
 
     test "reduces both" do
       assert %Function{params: [builtin(:integer)], return: 1..10} ==
-        Type.intersection(@any_with_integer, %Function{params: [builtin(:integer)], return: 1..10})
+        @any_with_integer <~> %Function{params: [builtin(:integer)], return: 1..10}
     end
 
     test "is none if the returns don't match" do
-      assert builtin(:none) == Type.intersection(@any_with_integer, %Function{params: :any, return: builtin(:atom)})
+      assert builtin(:none) == @any_with_integer <~> %Function{params: :any, return: builtin(:atom)}
     end
   end
 
   describe "a function with defined parameters" do
     test "intersects with self and the any function" do
       # zero arity
-      assert @zero_arity_any == Type.intersection(@zero_arity_any, @any_function)
-      assert @zero_arity_any == Type.intersection(@zero_arity_any, @zero_arity_any)
+      assert @zero_arity_any == @zero_arity_any <~> @any_function
+      assert @zero_arity_any == @zero_arity_any <~> @zero_arity_any
 
       # one arity
-      assert @one_arity_any == Type.intersection(@one_arity_any, @any_function)
-      assert @one_arity_any == Type.intersection(@one_arity_any, @one_arity_any)
+      assert @one_arity_any == @one_arity_any <~> @any_function
+      assert @one_arity_any == @one_arity_any <~> @one_arity_any
 
       # two arity
-      assert @two_arity_any == Type.intersection(@two_arity_any, @any_function)
-      assert @two_arity_any == Type.intersection(@two_arity_any, @two_arity_any)
+      assert @two_arity_any == @two_arity_any <~> @any_function
+      assert @two_arity_any == @two_arity_any <~> @two_arity_any
     end
 
     test "must match arities" do
-      assert builtin(:none) == Type.intersection(@zero_arity_any, @one_arity_any)
-      assert builtin(:none) == Type.intersection(@zero_arity_any, @two_arity_any)
-      assert builtin(:none) == Type.intersection(@one_arity_any, @two_arity_any)
+      assert builtin(:none) == @zero_arity_any <~> @one_arity_any
+      assert builtin(:none) == @zero_arity_any <~> @two_arity_any
+      assert builtin(:none) == @one_arity_any <~> @two_arity_any
     end
 
     test "reduces the return type" do
       assert %Function{params: [], return: builtin(:integer)} ==
-        Type.intersection(@zero_arity_any, %Function{params: [], return: builtin(:integer)})
+        @zero_arity_any <~> %Function{params: [], return: builtin(:integer)}
 
       assert %Function{params: [@any], return: builtin(:integer)} ==
-        Type.intersection(@one_arity_any, %Function{params: [@any], return: builtin(:integer)})
+        @one_arity_any <~> %Function{params: [@any], return: builtin(:integer)}
 
       assert %Function{params: [@any, @any], return: builtin(:integer)} ==
-        Type.intersection(@two_arity_any, %Function{params: [@any, @any], return: builtin(:integer)})
+        @two_arity_any <~> %Function{params: [@any, @any], return: builtin(:integer)}
     end
 
     test "reduces parameter types" do
       assert %Function{params: [builtin(:integer)], return: @any} ==
-        Type.intersection(@one_arity_any, %Function{params: [builtin(:integer)], return: @any})
+        @one_arity_any <~> %Function{params: [builtin(:integer)], return: @any}
 
       assert %Function{params: [builtin(:integer), @any], return: @any} ==
-        Type.intersection(@two_arity_any, %Function{params: [builtin(:integer), @any], return: @any})
+        @two_arity_any <~> %Function{params: [builtin(:integer), @any], return: @any}
 
       assert %Function{params: [@any, builtin(:atom)], return: @any} ==
-        Type.intersection(@two_arity_any, %Function{params: [@any, builtin(:atom)], return: @any})
+        @two_arity_any <~> %Function{params: [@any, builtin(:atom)], return: @any}
     end
 
     test "reduces both" do
       assert %Function{params: [builtin(:atom)], return: builtin(:integer)} ==
-        Type.intersection(@one_arity_any, %Function{params: [builtin(:atom)], return: builtin(:integer)})
+        @one_arity_any <~> %Function{params: [builtin(:atom)], return: builtin(:integer)}
     end
 
     test "is invalid if return mismatches" do
-      assert builtin(:none) == Type.intersection(
-        %Function{params: [@any], return: builtin(:integer)},
-        %Function{params: [@any], return: builtin(:atom)})
+      assert builtin(:none) ==
+        %Function{params: [@any], return: builtin(:integer)} <~>
+        %Function{params: [@any], return: builtin(:atom)}
     end
 
     test "is invalid if any parameter mismatches" do
-      assert builtin(:none) == Type.intersection(
-        %Function{params: [builtin(:integer)], return: @any},
-        %Function{params: [builtin(:atom)], return: @any})
+      assert builtin(:none) ==
+        %Function{params: [builtin(:integer)], return: @any} <~>
+        %Function{params: [builtin(:atom)], return: @any}
 
-      assert builtin(:none) == Type.intersection(
-        %Function{params: [builtin(:integer), @any], return: @any},
-        %Function{params: [builtin(:atom), @any], return: @any})
+      assert builtin(:none) ==
+        %Function{params: [builtin(:integer), @any], return: @any} <~>
+        %Function{params: [builtin(:atom), @any], return: @any}
 
-      assert builtin(:none) == Type.intersection(
-        %Function{params: [@any, builtin(:integer)], return: @any},
-        %Function{params: [@any, builtin(:atom)], return: @any})
+      assert builtin(:none) ==
+        %Function{params: [@any, builtin(:integer)], return: @any} <~>
+        %Function{params: [@any, builtin(:atom)], return: @any}
     end
   end
 

--- a/test/type/type_list/intersection_test.exs
+++ b/test/type/type_list/intersection_test.exs
@@ -24,8 +24,8 @@ defmodule TypeTest.TypeList.IntersectionTest do
     end
 
     test "with unions works as expected" do
-      assert [] == Type.intersection(%List{}, ([] | builtin(:atom)))
-      assert builtin(:none) == Type.intersection(%List{}, (builtin(:atom) | builtin(:port)))
+      assert [] == Type.intersection(%List{}, ([] <|> builtin(:atom)))
+      assert builtin(:none) == Type.intersection(%List{}, (builtin(:atom) <|> builtin(:port)))
     end
 
     test "doesn't intersect with anything else" do

--- a/test/type/type_list/intersection_test.exs
+++ b/test/type/type_list/intersection_test.exs
@@ -10,50 +10,50 @@ defmodule TypeTest.TypeList.IntersectionTest do
 
   describe "normal list" do
     test "intersects with any and self" do
-      assert %List{} == Type.intersection(%List{}, builtin(:any))
-      assert %List{} == Type.intersection(%List{}, %List{})
+      assert %List{} == %List{} <~> builtin(:any)
+      assert %List{} == %List{} <~> %List{}
     end
 
     test "intersects with empty list as empty list" do
-      assert [] == Type.intersection(%List{}, [])
+      assert [] == %List{} <~> []
     end
 
     test "intersects with another list with the intersection of types" do
-      assert %List{type: builtin(:integer)} == Type.intersection(%List{}, %List{type: builtin(:integer)})
-      assert %List{type: 47} == Type.intersection(%List{type: 47}, %List{type: builtin(:integer)})
+      assert %List{type: builtin(:integer)} == %List{} <~> %List{type: builtin(:integer)}
+      assert %List{type: 47} == %List{type: 47} <~> %List{type: builtin(:integer)}
     end
 
     test "with unions works as expected" do
-      assert [] == Type.intersection(%List{}, ([] <|> builtin(:atom)))
-      assert builtin(:none) == Type.intersection(%List{}, (builtin(:atom) <|> builtin(:port)))
+      assert [] == %List{} <~> ([] <|> builtin(:atom))
+      assert builtin(:none) == %List{} <~> (builtin(:atom) <|> builtin(:port))
     end
 
     test "doesn't intersect with anything else" do
       TypeTest.Targets.except([%List{}, []])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(%List{}, target)
+        assert builtin(:none) == %List{} <~> target
       end)
     end
   end
 
   describe "nonempty list" do
     test "intersects with any and self" do
-      assert %List{nonempty: true} == Type.intersection(%List{}, %List{nonempty: true})
-      assert %List{nonempty: true} == Type.intersection(%List{nonempty: true}, %List{})
+      assert %List{nonempty: true} == %List{} <~> %List{nonempty: true}
+      assert %List{nonempty: true} == %List{nonempty: true} <~> %List{}
     end
 
     test "doesn't intersect with empty list" do
-      assert builtin(:none) == Type.intersection([], %List{nonempty: true})
-      assert builtin(:none) == Type.intersection(%List{nonempty: true}, [])
+      assert builtin(:none) == [] <~> %List{nonempty: true}
+      assert builtin(:none) == %List{nonempty: true} <~> []
     end
   end
 
   describe "list finals" do
     test "are reduced" do
       assert %List{final: builtin(:pos_integer)} ==
-        Type.intersection(%List{final: builtin(:pos_integer)}, %List{final: builtin(:integer)})
+        %List{final: builtin(:pos_integer)} <~> %List{final: builtin(:integer)}
       assert %List{final: builtin(:pos_integer)} ==
-        Type.intersection(%List{final: builtin(:integer)}, %List{final: builtin(:pos_integer)})
+        %List{final: builtin(:integer)} <~> %List{final: builtin(:pos_integer)}
     end
   end
 end

--- a/test/type/type_list/subtype_test.exs
+++ b/test/type/type_list/subtype_test.exs
@@ -20,11 +20,11 @@ defmodule TypeTest.TypeList.SubtypeTest do
     end
 
     test "is a subtype of correct unions" do
-      assert %List{type: 5} in (%List{type: builtin(:integer)} | builtin(:atom))
+      assert %List{type: 5} in (%List{type: builtin(:integer)} <|> builtin(:atom))
     end
 
     test "is not a subtype of unions of orthogonal types" do
-      refute %List{type: builtin(:integer)} in (%List{type: builtin(:atom)} | builtin(:atom))
+      refute %List{type: builtin(:integer)} in (%List{type: builtin(:atom)} <|> builtin(:atom))
     end
 
     test "is not a subtype if the inner type is not a subtype" do

--- a/test/type/type_list/usable_as_test.exs
+++ b/test/type/type_list/usable_as_test.exs
@@ -15,11 +15,11 @@ defmodule TypeTest.TypeList.UsableAsTest do
     end
 
     test "is usable as a union with the list type" do
-      assert :ok = %List{} ~> (%List{} | builtin(:atom))
+      assert :ok = %List{} ~> (%List{} <|> builtin(:atom))
     end
 
     test "is not usable as a union with orthogonal type" do
-      assert {:error, _} = %List{} ~> (builtin(:integer) | builtin(:atom))
+      assert {:error, _} = %List{} ~> (builtin(:integer) <|> builtin(:atom))
     end
 
     test "is not usable as any of the other types" do

--- a/test/type/type_map/intersection_test.exs
+++ b/test/type/type_map/intersection_test.exs
@@ -45,10 +45,10 @@ defmodule TypeTest.TypeMap.IntersectionTest do
     test "segments its matches correctly" do
       # These maps can take integers.
       # Map 1:      0   3       5      7
-      # <-----------|---|-------|------|-->
-      #    atom         |<-int->| atom |
+      # <-----------<|>---<|>-------<|>------<|>-->
+      #    atom         <|><-int-><|> atom <|>
       # Map 2:      0
-      # <-----------|---------------->
+      # <-----------<|>---------------->
       #               atom
       #
       # intersection should be 0..2 => atom, 6..7 => atom

--- a/test/type/type_map/intersection_test.exs
+++ b/test/type/type_map/intersection_test.exs
@@ -13,21 +13,21 @@ defmodule TypeTest.TypeMap.IntersectionTest do
 
   describe "the empty map" do
     test "intersects with any and self" do
-      assert %Map{} == Type.intersection(%Map{}, builtin(:any))
-      assert %Map{} == Type.intersection(%Map{}, %Map{})
+      assert %Map{} == %Map{} <~> builtin(:any)
+      assert %Map{} == %Map{} <~> %Map{}
     end
   end
 
   describe "the arbitrary map" do
     test "intersects with any and self" do
-      assert @any_map == Type.intersection(@any_map, builtin(:any))
-      assert @any_map == Type.intersection(@any_map, @any_map)
+      assert @any_map == @any_map <~> builtin(:any)
+      assert @any_map == @any_map <~> @any_map
     end
 
     test "intersects with no other type" do
       TypeTest.Targets.except([@any_map])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(@any_map, target)
+        assert builtin(:none) == @any_map <~> target
       end)
     end
   end
@@ -36,8 +36,8 @@ defmodule TypeTest.TypeMap.IntersectionTest do
     test "intersects with empty map" do
       int_any_map = Map.build(%{builtin(:integer) => @any})
 
-      assert int_any_map == Type.intersection(int_any_map, @any_map)
-      assert int_any_map == Type.intersection(int_any_map, int_any_map)
+      assert int_any_map == int_any_map <~> @any_map
+      assert int_any_map == int_any_map <~> int_any_map
     end
   end
 
@@ -59,8 +59,7 @@ defmodule TypeTest.TypeMap.IntersectionTest do
       map2 = Map.build(%{builtin(:pos_integer) => builtin(:atom)})
 
       assert Map.build(%{1..2 => builtin(:atom),
-                         6..7 => builtin(:atom)}) ==
-               Type.intersection(map1, map2)
+                         6..7 => builtin(:atom)}) == map1 <~> map2
     end
   end
 
@@ -68,41 +67,36 @@ defmodule TypeTest.TypeMap.IntersectionTest do
   describe "maps with required types" do
     test "intersect with the intersection of the values" do
       assert Map.build(%{foo: 3..5}, %{}) ==
-        Type.intersection(Map.build(%{foo: 1..5}, %{}),
-                          Map.build(%{foo: 3..8}, %{}))
+        Map.build(%{foo: 1..5}, %{}) <~>
+        Map.build(%{foo: 3..8}, %{})
     end
 
     test "intersect with none if they don't match" do
-      assert builtin(:none) == Type.intersection(@foo_int,
-                                Map.build(%{bar: builtin(:integer)}, %{}))
+      assert builtin(:none) == @foo_int <~> Map.build(%{bar: builtin(:integer)}, %{})
     end
 
     test "intersect with none if their value types don't match" do
-      assert builtin(:none) == Type.intersection(@foo_int,
-                                 Map.build(%{foo: builtin(:atom)}, %{}))
+      assert builtin(:none) == @foo_int <~> Map.build(%{foo: builtin(:atom)}, %{})
     end
   end
 
   describe "maps with matching required and optional types" do
     test "convert optionals to required" do
-      assert @foo_int == Type.intersection(@foo_int,
-                           Map.build(foo: builtin(:integer)))
+      assert @foo_int == @foo_int <~> Map.build(foo: builtin(:integer))
     end
 
     test "intersect optional key types, if necessary" do
-      assert @foo_int == Type.intersection(@foo_int,
-                           Map.build(%{builtin(:atom) => builtin(:integer)}))
+      assert @foo_int == @foo_int <~> Map.build(%{builtin(:atom) => builtin(:integer)})
     end
 
     test "intersect value types" do
       assert Map.build(%{foo: 1..10}, %{}) ==
-        Type.intersection(@foo_int,
-                          Map.build(%{builtin(:atom) => 1..10}))
+        @foo_int <~> Map.build(%{builtin(:atom) => 1..10})
     end
 
     test "intersect with none if it's impossible to construct the required" do
-      assert builtin(:none) == Type.intersection(@foo_int,
-                           Map.build(%{builtin(:integer) => builtin(:integer)}))
+      assert builtin(:none) ==
+        @foo_int <~> Map.build(%{builtin(:integer) => builtin(:integer)})
     end
   end
 end

--- a/test/type/type_map/union_test.exs
+++ b/test/type/type_map/union_test.exs
@@ -13,38 +13,38 @@ defmodule TypeTest.TypeMap.UnionTest do
   describe "for the empty map type" do
     test "union with an optional or required term is the same" do
       assert Map.build(foo: @any) ==
-        (@empty_map | Map.build(%{foo: @any}, %{}))
+        (@empty_map <|> Map.build(%{foo: @any}, %{}))
       assert Map.build(foo: @any) ==
-        (@empty_map | Map.build(foo: @any))
+        (@empty_map <|> Map.build(foo: @any))
       assert Map.build(%{foo: @any, bar: builtin(:integer)}) ==
-        (@empty_map | Map.build(%{foo: @any}, %{bar: builtin(:integer)}))
+        (@empty_map <|> Map.build(%{foo: @any}, %{bar: builtin(:integer)}))
     end
   end
 
   describe "for a map with a required type" do
     test "union with the same type, but optional is optional" do
       assert Map.build(foo: @any) ==
-        (Map.build(foo: @any) | Map.build(foo: @any))
+        (Map.build(foo: @any) <|> Map.build(foo: @any))
     end
 
     test "unions are not merged for disjoint required types" do
       assert %Type.Union{} =
-        (Map.build(foo: @any) | Map.build(bar: @any))
+        (Map.build(foo: @any) <|> Map.build(bar: @any))
     end
   end
 
   describe "you can merge two maps if" do
     test "they are equal" do
       assert Map.build(foo: @any) ==
-        (Map.build(foo: @any) | Map.build(foo: @any))
+        (Map.build(foo: @any) <|> Map.build(foo: @any))
     end
     test "they have the same keys with one side having bigger values" do
       assert Map.build(foo: @any) ==
-        (Map.build(foo: @any) | Map.build(foo: builtin(:integer)))
+        (Map.build(foo: @any) <|> Map.build(foo: builtin(:integer)))
     end
     test "the side that has more keys also has more values" do
       assert Map.build(foo: @any, bar: builtin(:integer)) ==
-        (Map.build(foo: @any, bar: builtin(:integer)) |
+        (Map.build(foo: @any, bar: builtin(:integer)) <|>
          Map.build(foo: builtin(:integer)))
     end
   end
@@ -52,7 +52,7 @@ defmodule TypeTest.TypeMap.UnionTest do
   describe "you can't merge two maps if" do
     test "key types are disjoint" do
       assert %Type.Union{} =
-        (Map.build(foo: @any) | Map.build(bar: @any))
+        (Map.build(foo: @any) <|> Map.build(bar: @any))
     end
     test "value sizes are inconsistent" do
       ## Why is this?  Because in this case %{foo: :baz, bar: :baz}
@@ -60,12 +60,12 @@ defmodule TypeTest.TypeMap.UnionTest do
       ## the union.
 
       assert %Type.Union{} =
-        (Map.build(foo: @any, bar: builtin(:integer)) |
+        (Map.build(foo: @any, bar: builtin(:integer)) <|>
          Map.build(foo: builtin(:integer), bar: @any))
     end
     test "the side that has extra keys has even one value that's smaller" do
       assert %Type.Union{} =
-        (Map.build(foo: @any, bar: 1..10, baz: builtin(:atom), quux: builtin(:integer)) |
+        (Map.build(foo: @any, bar: 1..10, baz: builtin(:atom), quux: builtin(:integer)) <|>
          Map.build(foo: @any, bar: builtin(:integer), baz: :ping))
     end
   end

--- a/test/type/type_tuple/intersection_test.exs
+++ b/test/type/type_tuple/intersection_test.exs
@@ -12,26 +12,26 @@ defmodule TypeTest.TypeTuple.IntersectionTest do
 
   describe "any tuple" do
     test "intersects with any and self" do
-      assert @anytuple == Type.intersection(@anytuple, builtin(:any))
-      assert @anytuple == Type.intersection(@anytuple, @anytuple)
+      assert @anytuple == @anytuple <~> builtin(:any)
+      assert @anytuple == @anytuple <~> @anytuple
     end
 
     test "turns into its counterparty" do
-      assert %Tuple{elements: []} == Type.intersection(@anytuple, %Tuple{elements: []})
-      assert %Tuple{elements: [:foo]} == Type.intersection(@anytuple, %Tuple{elements: [:foo]})
+      assert %Tuple{elements: []} == @anytuple <~> %Tuple{elements: []}
+      assert %Tuple{elements: [:foo]} == @anytuple <~> %Tuple{elements: [:foo]}
       assert %Tuple{elements: [:foo, builtin(:integer)]} ==
-        Type.intersection(@anytuple, %Tuple{elements: [:foo, builtin(:integer)]})
+        @anytuple <~> %Tuple{elements: [:foo, builtin(:integer)]}
     end
 
     test "with unions works as expected" do
-      assert %Tuple{elements: []} == Type.intersection(@anytuple, (%Tuple{elements: []} <|> 1..10))
-      assert builtin(:none) == Type.intersection(@anytuple, (builtin(:atom) <|> builtin(:port)))
+      assert %Tuple{elements: []} == @anytuple <~> (%Tuple{elements: []} <|> 1..10)
+      assert builtin(:none) == @anytuple <~> (builtin(:atom) <|> builtin(:port))
     end
 
     test "doesn't intersect with anything else" do
       TypeTest.Targets.except([@anytuple, %Tuple{elements: []}])
       |> Enum.each(fn target ->
-        assert builtin(:none) == Type.intersection(@anytuple, target)
+        assert builtin(:none) == @anytuple <~> target
       end)
     end
   end
@@ -39,22 +39,27 @@ defmodule TypeTest.TypeTuple.IntersectionTest do
   describe "tuples with defined elements" do
     test "intersect with the cartesian intersection" do
       assert %Tuple{elements: [:foo]} ==
-        Type.intersection(%Tuple{elements: [:foo]}, %Tuple{elements: [builtin(:atom)]})
+        %Tuple{elements: [:foo]} <~>
+        %Tuple{elements: [builtin(:atom)]}
       assert %Tuple{elements: [:foo]} ==
-        Type.intersection(%Tuple{elements: [builtin(:atom)]}, %Tuple{elements: [:foo]})
+        %Tuple{elements: [builtin(:atom)]} <~>
+        %Tuple{elements: [:foo]}
 
       assert %Tuple{elements: [:foo, 47]} ==
-        Type.intersection(%Tuple{elements: [:foo, builtin(:integer)]}, %Tuple{elements: [builtin(:atom), 47]})
+        %Tuple{elements: [:foo, builtin(:integer)]} <~>
+        %Tuple{elements: [builtin(:atom), 47]}
       assert %Tuple{elements: [:foo, 47]} ==
-        Type.intersection(%Tuple{elements: [builtin(:atom), builtin(:integer)]}, %Tuple{elements: [:foo, 47]})
+        %Tuple{elements: [builtin(:atom), builtin(:integer)]} <~>
+        %Tuple{elements: [:foo, 47]}
       assert %Tuple{elements: [:foo, 47]} ==
-        Type.intersection(%Tuple{elements: [:foo, 47]}, %Tuple{elements: [builtin(:atom), builtin(:integer)]})
+        %Tuple{elements: [:foo, 47]} <~>
+        %Tuple{elements: [builtin(:atom), builtin(:integer)]}
     end
 
     test "a single mismatch yields none" do
-      assert builtin(:none) == Type.intersection(%Tuple{elements: [:foo]}, %Tuple{elements: [:bar]})
-      assert builtin(:none) == Type.intersection(%Tuple{elements: [:foo, :bar]}, %Tuple{elements: [:bar, :bar]})
-      assert builtin(:none) == Type.intersection(%Tuple{elements: [:bar, :bar]}, %Tuple{elements: [:bar, :foo]})
+      assert builtin(:none) == %Tuple{elements: [:foo]} <~> %Tuple{elements: [:bar]}
+      assert builtin(:none) == %Tuple{elements: [:foo, :bar]} <~> %Tuple{elements: [:bar, :bar]}
+      assert builtin(:none) == %Tuple{elements: [:bar, :bar]} <~> %Tuple{elements: [:bar, :foo]}
     end
   end
 end

--- a/test/type/type_tuple/intersection_test.exs
+++ b/test/type/type_tuple/intersection_test.exs
@@ -24,8 +24,8 @@ defmodule TypeTest.TypeTuple.IntersectionTest do
     end
 
     test "with unions works as expected" do
-      assert %Tuple{elements: []} == Type.intersection(@anytuple, (%Tuple{elements: []} | 1..10))
-      assert builtin(:none) == Type.intersection(@anytuple, (builtin(:atom) | builtin(:port)))
+      assert %Tuple{elements: []} == Type.intersection(@anytuple, (%Tuple{elements: []} <|> 1..10))
+      assert builtin(:none) == Type.intersection(@anytuple, (builtin(:atom) <|> builtin(:port)))
     end
 
     test "doesn't intersect with anything else" do

--- a/test/type/type_tuple/subtype_test.exs
+++ b/test/type/type_tuple/subtype_test.exs
@@ -17,11 +17,11 @@ defmodule TypeTest.TypeTuple.SubtypeTest do
     end
 
     test "are subtypes of tuples containing any tuples" do
-      assert @any_tuple in (builtin(:atom) | @any_tuple)
+      assert @any_tuple in (builtin(:atom) <|> @any_tuple)
     end
 
     test "are not subtypes of orthogonal unions" do
-      refute @any_tuple in (builtin(:atom) | builtin(:integer))
+      refute @any_tuple in (builtin(:atom) <|> builtin(:integer))
     end
 
     test "are not subtypes of other types" do
@@ -53,9 +53,9 @@ defmodule TypeTest.TypeTuple.SubtypeTest do
     end
 
     test "are subtypes of unions with themselves, supertuples, or any tuple" do
-      assert %Tuple{elements: [builtin(:integer)]} in (%Tuple{elements: [builtin(:integer)]} | builtin(:integer))
-      assert %Tuple{elements: [builtin(:integer)]} in (%Tuple{elements: [builtin(:any)]} | builtin(:integer))
-      assert %Tuple{elements: [builtin(:integer)]} in (@any_tuple| builtin(:integer))
+      assert %Tuple{elements: [builtin(:integer)]} in (%Tuple{elements: [builtin(:integer)]} <|> builtin(:integer))
+      assert %Tuple{elements: [builtin(:integer)]} in (%Tuple{elements: [builtin(:any)]} <|> builtin(:integer))
+      assert %Tuple{elements: [builtin(:integer)]} in (@any_tuple<|> builtin(:integer))
     end
 
     test "are subtypes when their elements are subtypes" do
@@ -65,7 +65,7 @@ defmodule TypeTest.TypeTuple.SubtypeTest do
 
     test "are not subtypes of orthogonal unions" do
       refute %Tuple{elements: [builtin(:integer)]} in
-        (%Tuple{elements: [builtin(:integer), builtin(:integer)]} | builtin(:integer))
+        (%Tuple{elements: [builtin(:integer), builtin(:integer)]} <|> builtin(:integer))
     end
 
     test "is not a subtype on partial match" do

--- a/test/type/type_tuple/usable_as_test.exs
+++ b/test/type/type_tuple/usable_as_test.exs
@@ -17,7 +17,7 @@ defmodule TypeTest.TypeTuple.UsableAsTest do
     end
 
     test "you can use it in a union type" do
-      assert :ok = @any_tuple ~> (@any_tuple | builtin(:atom))
+      assert :ok = @any_tuple ~> (@any_tuple <|> builtin(:atom))
     end
 
     test "it might be usable as a specified tuple" do
@@ -30,7 +30,7 @@ defmodule TypeTest.TypeTuple.UsableAsTest do
     end
 
     test "you can't use it in a union type of orthogonal types" do
-      assert {:error, _} = @any_tuple ~> (builtin(:integer) | :infinity)
+      assert {:error, _} = @any_tuple ~> (builtin(:integer) <|> :infinity)
     end
 
     test "you can't use it for anything else" do

--- a/test/type/type_union/intersection_test.exs
+++ b/test/type/type_union/intersection_test.exs
@@ -9,17 +9,17 @@ defmodule TypeTest.TypeUnion.IntersectionTest do
 
   describe "unions" do
     test "are all part of any" do
-      assert (1 | 3) == Type.intersection((1 | 3), builtin(:any))
-      assert (1 | 3) == Type.intersection((1 | 3), (1 | 3))
+      assert (1 <|> 3) == Type.intersection((1 <|> 3), builtin(:any))
+      assert (1 <|> 3) == Type.intersection((1 <|> 3), (1 <|> 3))
     end
 
     test "are disjoint" do
-      assert builtin(:none) == Type.intersection((1 | 3), (2 | 5))
+      assert builtin(:none) == Type.intersection((1 <|> 3), (2 <|> 5))
     end
 
     test "get the overlap" do
-      #assert (1 | 3) == Type.intersection((0..1 | 3..4), 1..3)
-      assert (1 | 3 | 5) == Type.intersection((0..1 | 3..5), (1..3 | 5..6))
+      #assert (1 <|> 3) == Type.intersection((0..1 <|> 3..4), 1..3)
+      assert (1 <|> 3 <|> 5) == Type.intersection((0..1 <|> 3..5), (1..3 <|> 5..6))
     end
   end
 

--- a/test/type/type_union/intersection_test.exs
+++ b/test/type/type_union/intersection_test.exs
@@ -9,17 +9,17 @@ defmodule TypeTest.TypeUnion.IntersectionTest do
 
   describe "unions" do
     test "are all part of any" do
-      assert (1 <|> 3) == Type.intersection((1 <|> 3), builtin(:any))
-      assert (1 <|> 3) == Type.intersection((1 <|> 3), (1 <|> 3))
+      assert (1 <|> 3) == (1 <|> 3) <~> builtin(:any)
+      assert (1 <|> 3) == (1 <|> 3) <~> (1 <|> 3)
     end
 
     test "are disjoint" do
-      assert builtin(:none) == Type.intersection((1 <|> 3), (2 <|> 5))
+      assert builtin(:none) == (1 <|> 3) <~> (2 <|> 5)
     end
 
     test "get the overlap" do
-      #assert (1 <|> 3) == Type.intersection((0..1 <|> 3..4), 1..3)
-      assert (1 <|> 3 <|> 5) == Type.intersection((0..1 <|> 3..5), (1..3 <|> 5..6))
+      assert (1 <|> 3) == (0..1 <|> 3..4) <~> 1..3
+      assert (1 <|> 3 <|> 5) == (0..1 <|> 3..5) <~> (1..3 <|> 5..6)
     end
   end
 

--- a/test/type/type_union/order_test.exs
+++ b/test/type/type_union/order_test.exs
@@ -9,26 +9,26 @@ defmodule TypeTest.TypeUnion.OrderTest do
 
   describe "a union" do
     test "is bigger than bottom and pid" do
-      assert (1 | :foo) > builtin(:none)
-      assert (1 | :foo) < builtin(:any)
+      assert (1 <|> :foo) > builtin(:none)
+      assert (1 <|> :foo) < builtin(:any)
     end
 
     test "is just bigger than its biggest element" do
-      assert (1 | 3) > 3
-      assert (1 | 3) < 4
-      assert (1 | 3..4) > 3..4
-      assert (1..2 | 4) < 3..5
-      assert (1 | 3..4) < 3..5
+      assert (1 <|> 3) > 3
+      assert (1 <|> 3) < 4
+      assert (1 <|> 3..4) > 3..4
+      assert (1..2 <|> 4) < 3..5
+      assert (1 <|> 3..4) < 3..5
     end
 
     test "for integer ranges if everything is in the range it's smaller" do
-      assert (1 | 3..4) < 0..4
-      assert (1..2 | 4) < 0..4
+      assert (1 <|> 3..4) < 0..4
+      assert (1..2 <|> 4) < 0..4
     end
 
     test "is bigger when it's categorically bigger" do
-      assert (1 | builtin(:atom)) > builtin(:atom)
-      assert (1 | :atom) > :atom
+      assert (1 <|> builtin(:atom)) > builtin(:atom)
+      assert (1 <|> :atom) > :atom
     end
   end
 end

--- a/test/type/type_union/subtype_test.exs
+++ b/test/type/type_union/subtype_test.exs
@@ -9,21 +9,21 @@ defmodule TypeTest.TypeUnion.SubtypeTest do
 
   describe "union types" do
     test "are in themselves and in any" do
-      assert (1 | :foo) in (1 | :foo)
-      assert (1 | :foo) in builtin(:any)
+      assert (1 <|> :foo) in (1 <|> :foo)
+      assert (1 <|> :foo) in builtin(:any)
     end
 
     test "can be in more general unions" do
-      assert (1 | :foo) in (builtin(:integer) | builtin(:atom))
+      assert (1 <|> :foo) in (builtin(:integer) <|> builtin(:atom))
     end
 
     test "can be totally inside of a single type" do
-      assert (:foo | :bar) in builtin(:atom)
+      assert (:foo <|> :bar) in builtin(:atom)
     end
 
     test "are not inside if a single element doesn't match" do
-      refute (1 | :foo) in builtin(:integer)
-      refute (1 | :foo) in builtin(:atom)
+      refute (1 <|> :foo) in builtin(:integer)
+      refute (1 <|> :foo) in builtin(:atom)
     end
   end
 

--- a/test/type/type_union/usable_as_test.exs
+++ b/test/type/type_union/usable_as_test.exs
@@ -8,18 +8,18 @@ defmodule TypeTest.TypeUnion.UsableAsTest do
 
   describe "for union types" do
     test "you can use it for itself and the builtin any" do
-      assert :ok = (1 | :foo) ~> (1 | :foo)
-      assert :ok = (1 | :foo) ~> builtin(:any)
+      assert :ok = (1 <|> :foo) ~> (1 <|> :foo)
+      assert :ok = (1 <|> :foo) ~> builtin(:any)
     end
 
     test "it's usable as self or a bigger union" do
-      assert :ok = (1 | :foo) ~> (1 | :foo)
-      assert :ok = (1 | :bar) ~> (1 | :bar | :foo)
+      assert :ok = (1 <|> :foo) ~> (1 <|> :foo)
+      assert :ok = (1 <|> :bar) ~> (1 <|> :bar <|> :foo)
     end
 
     test "it might be usable as one of its elements" do
-      assert {:maybe, _} = (1 | :foo) ~> 1
-      assert {:maybe, _} = (1 | :foo) ~> :foo
+      assert {:maybe, _} = (1 <|> :foo) ~> 1
+      assert {:maybe, _} = (1 <|> :foo) ~> :foo
     end
   end
 

--- a/test/type_test.exs
+++ b/test/type_test.exs
@@ -73,8 +73,8 @@ defmodule TypeTest do
 
     test "assigns proper lists correctly, and makes them nonempty" do
       assert %Type.List{type: 1, nonempty: true} == Type.of([1, 1, 1])
-      assert %Type.List{type: (1 | :foo), nonempty: true} == Type.of([1, :foo, :foo])
-      assert %Type.List{type: (1 | :foo | builtin(:pid)), nonempty: true} == Type.of([self(), 1, :foo])
+      assert %Type.List{type: (1 <|> :foo), nonempty: true} == Type.of([1, :foo, :foo])
+      assert %Type.List{type: (1 <|> :foo <|> builtin(:pid)), nonempty: true} == Type.of([self(), 1, :foo])
     end
 
     test "assigns improper lists correctly" do

--- a/test/union_test.exs
+++ b/test/union_test.exs
@@ -9,6 +9,14 @@ defmodule TypeTest.UnionTest do
 
   import Type, only: [builtin: 1]
 
+  test "unions keep terms in reverse order" do
+    assert %Union{of: [47, 0]} = Union.of(47, 0)
+    assert %Union{of: [47, 0]} = Union.of(0, 47)
+
+    assert %Union{of: [:foo, 47]} = Union.of(:foo, 47)
+    assert %Union{of: [:foo, 47]} = Union.of(47, :foo)
+  end
+
   describe "unions are collectibles" do
     test "putting nothing into the union creates nonetype" do
       assert %Type{name: :none} = Enum.into([], %Union{})
@@ -19,125 +27,125 @@ defmodule TypeTest.UnionTest do
     end
 
     test "multiple elements in the union are dropped together" do
-      assert %Union{of: [1, 3]} = Enum.into([1, 3], %Union{})
+      assert %Union{of: [3, 1]} = Enum.into([1, 3], %Union{})
     end
 
     test "when you send a union into collectible, it gets unwrapped" do
-      assert %Union{of: [1, 3, 5, 7]} = Enum.into([%Union{of: [1, 3]}, %Union{of: [5, 7]}], %Union{})
+      assert %Union{of: [7, 5, 3, 1]} = Enum.into([%Union{of: [1, 5]}, %Union{of: [3, 7]}], %Union{})
     end
   end
 
   describe "when collecting integers in unions" do
     test "adjacent integers are turned into ranges" do
-      assert 1..2 == (2 | 1)
+      assert 1..2 == (2 <|> 1)
     end
 
     test "a preceding range is merged in" do
-      assert 1..3 == (3 | 1..2)
+      assert 1..3 == (3 <|> 1..2)
     end
   end
 
   describe "when collecting ranges in unions" do
     test "a preceding integer is merged in" do
-      assert 1..3 == (2..3 | 1)
+      assert 1..3 == (2..3 <|> 1)
     end
 
     test "overlapping ranges are merged" do
-      assert 1..4 == (2..4 | 1..3)
-      assert 1..3 == (2..3 | 1..2)
+      assert 1..4 == (2..4 <|> 1..3)
+      assert 1..3 == (2..3 <|> 1..2)
     end
 
     test "adjacent ranges are merged" do
-      assert 1..4 == (1..2 | 3..4)
+      assert 1..4 == (1..2 <|> 3..4)
     end
   end
 
   describe "when collecting neg_integer in unions" do
     test "collects negative integers" do
-      assert builtin(:neg_integer) == (builtin(:neg_integer) | -2)
+      assert builtin(:neg_integer) == (builtin(:neg_integer) <|> -2)
     end
     test "collects negative ranges" do
-      assert builtin(:neg_integer) == (builtin(:neg_integer) | -10..-2)
+      assert builtin(:neg_integer) == (builtin(:neg_integer) <|> -10..-2)
     end
     test "collects partially negative ranges" do
-      assert (builtin(:neg_integer) | 0) == (builtin(:neg_integer) | -10..0)
-      assert (builtin(:neg_integer) | 0..1) == (builtin(:neg_integer) | -10..1)
+      assert (builtin(:neg_integer) <|> 0) == (builtin(:neg_integer) <|> -10..0)
+      assert (builtin(:neg_integer) <|> 0..1) == (builtin(:neg_integer) <|> -10..1)
     end
   end
 
   describe "when collecting pos_integer in unions" do
     test "collects positive integers" do
-      assert builtin(:pos_integer) == (builtin(:pos_integer) | 2)
+      assert builtin(:pos_integer) == (builtin(:pos_integer) <|> 2)
     end
     test "collects positive ranges" do
-      assert builtin(:pos_integer) == (builtin(:pos_integer) | 2..10)
+      assert builtin(:pos_integer) == (builtin(:pos_integer) <|> 2..10)
     end
     test "collects zero" do
-      assert builtin(:non_neg_integer) == (builtin(:pos_integer) | 0)
+      assert builtin(:non_neg_integer) == (builtin(:pos_integer) <|> 0)
     end
     test "collects ranges with zero" do
-      assert builtin(:non_neg_integer) == (builtin(:pos_integer) | 0..10)
+      assert builtin(:non_neg_integer) == (builtin(:pos_integer) <|> 0..10)
     end
     test "collects ranges ending in zero" do
-      assert (-1 | builtin(:non_neg_integer)) == (builtin(:pos_integer) | -1..0)
-      assert (-3..-1 | builtin(:non_neg_integer)) == (builtin(:pos_integer) | -3..0)
+      assert (-1 <|> builtin(:non_neg_integer)) == (builtin(:pos_integer) <|> -1..0)
+      assert (-3..-1 <|> builtin(:non_neg_integer)) == (builtin(:pos_integer) <|> -3..0)
     end
     test "collects ranges not ending in zero" do
-      assert (-1 | builtin(:non_neg_integer)) == (builtin(:pos_integer) | -1..10)
-      assert (-3..-1 | builtin(:non_neg_integer)) == (builtin(:pos_integer) | -3..10)
+      assert (-1 <|> builtin(:non_neg_integer)) == (builtin(:pos_integer) <|> -1..10)
+      assert (-3..-1 <|> builtin(:non_neg_integer)) == (builtin(:pos_integer) <|> -3..10)
     end
   end
 
   describe "when collecting non_neg_integer in unions" do
     test "collects non negative integers" do
-      assert builtin(:non_neg_integer) == (builtin(:non_neg_integer) | 0)
-      assert builtin(:non_neg_integer) == (builtin(:non_neg_integer) | 2)
+      assert builtin(:non_neg_integer) == (builtin(:non_neg_integer) <|> 0)
+      assert builtin(:non_neg_integer) == (builtin(:non_neg_integer) <|> 2)
     end
     test "collects non negative ranges" do
-      assert builtin(:non_neg_integer) == (builtin(:non_neg_integer) | 0..10)
-      assert builtin(:non_neg_integer) == (builtin(:non_neg_integer) | 2..10)
+      assert builtin(:non_neg_integer) == (builtin(:non_neg_integer) <|> 0..10)
+      assert builtin(:non_neg_integer) == (builtin(:non_neg_integer) <|> 2..10)
     end
     test "collects ranges ending in zero" do
-      assert (-1 | builtin(:non_neg_integer)) == (builtin(:non_neg_integer) | -1..0)
-      assert (-3..-1 | builtin(:non_neg_integer)) == (builtin(:non_neg_integer) | -3..0)
+      assert (-1 <|> builtin(:non_neg_integer)) == (builtin(:non_neg_integer) <|> -1..0)
+      assert (-3..-1 <|> builtin(:non_neg_integer)) == (builtin(:non_neg_integer) <|> -3..0)
     end
     test "collects ranges not ending in zero" do
-      assert (-1 | builtin(:non_neg_integer)) == (builtin(:non_neg_integer) | -1..10)
-      assert (-3..-1 | builtin(:non_neg_integer)) == (builtin(:non_neg_integer) | -3..10)
+      assert (-1 <|> builtin(:non_neg_integer)) == (builtin(:non_neg_integer) <|> -1..10)
+      assert (-3..-1 <|> builtin(:non_neg_integer)) == (builtin(:non_neg_integer) <|> -3..10)
     end
     test "fuses with neg_integer" do
-      assert builtin(:integer) == (builtin(:neg_integer) | builtin(:non_neg_integer))
+      assert builtin(:integer) == (builtin(:neg_integer) <|> builtin(:non_neg_integer))
     end
   end
 
   describe "when collecting integer in unions" do
     test "collects neg_integer" do
-      assert builtin(:integer) == (builtin(:integer) | builtin(:neg_integer))
+      assert builtin(:integer) == (builtin(:integer) <|> builtin(:neg_integer))
     end
     test "collects integers" do
-      assert builtin(:integer) == (builtin(:integer) | -1)
+      assert builtin(:integer) == (builtin(:integer) <|> -1)
     end
     test "collects non_neg_integer" do
-      assert builtin(:integer) == (builtin(:integer) | builtin(:non_neg_integer))
+      assert builtin(:integer) == (builtin(:integer) <|> builtin(:non_neg_integer))
     end
     test "collects pos_integer" do
-      assert builtin(:integer) == (builtin(:integer) | builtin(:pos_integer))
+      assert builtin(:integer) == (builtin(:integer) <|> builtin(:pos_integer))
     end
     test "collects ranges" do
-      assert builtin(:integer) == (builtin(:integer) | -3..10)
+      assert builtin(:integer) == (builtin(:integer) <|> -3..10)
     end
   end
 
   test "full integer fusion" do
-    assert builtin(:integer) = (builtin(:neg_integer) | 0 | builtin(:pos_integer))
-    assert builtin(:integer) = (builtin(:neg_integer) | 0..3 | builtin(:pos_integer))
-    assert builtin(:integer) = (builtin(:neg_integer) | -1..3 | builtin(:pos_integer))
+    assert builtin(:integer) = (builtin(:neg_integer) <|> 0 <|> builtin(:pos_integer))
+    assert builtin(:integer) = (builtin(:neg_integer) <|> 0..3 <|> builtin(:pos_integer))
+    assert builtin(:integer) = (builtin(:neg_integer) <|> -1..3 <|> builtin(:pos_integer))
   end
 
   test "builtin atom collects atoms" do
-    assert :foo == (:foo | :foo)
-    assert builtin(:atom) = (builtin(:atom) | :foo)
-    assert builtin(:atom) = (builtin(:atom) | :bar)
+    assert :foo == (:foo <|> :foo)
+    assert builtin(:atom) = (builtin(:atom) <|> :foo)
+    assert builtin(:atom) = (builtin(:atom) <|> :bar)
   end
 
   alias Type.Tuple
@@ -148,23 +156,23 @@ defmodule TypeTest.UnionTest do
 
   describe "for the tuple type" do
     test "anytuple merges other all tuples" do
-      assert @anytuple == (@anytuple | %Tuple{elements: []})
-      assert @anytuple == (@anytuple | %Tuple{elements: [@any]})
-      assert @anytuple == (@anytuple | %Tuple{elements: [:foo]} | %Tuple{elements: [:bar]})
+      assert @anytuple == (@anytuple <|> %Tuple{elements: []})
+      assert @anytuple == (@anytuple <|> %Tuple{elements: [@any]})
+      assert @anytuple == (@anytuple <|> %Tuple{elements: [:foo]} <|> %Tuple{elements: [:bar]})
     end
 
     test "tuples are merged if their elements can merge" do
-      assert %Tuple{elements: [@any, :bar]} == (%Tuple{elements: [@any, :bar]} | %Tuple{elements: [:foo, :bar]})
+      assert %Tuple{elements: [@any, :bar]} == (%Tuple{elements: [@any, :bar]} <|> %Tuple{elements: [:foo, :bar]})
 
-      assert %Tuple{elements: [:bar, @any]} == (%Tuple{elements: [:bar, @any]} | %Tuple{elements: [:bar, :foo]})
+      assert %Tuple{elements: [:bar, @any]} == (%Tuple{elements: [:bar, @any]} <|> %Tuple{elements: [:bar, :foo]})
 
-      assert (%Tuple{elements: [:foo, @any]} | %Tuple{elements: [@any, :bar]}) ==
-        (%Tuple{elements: [@any, :bar]} | %Tuple{elements: [:foo, @any]} | %Tuple{elements: [:foo, :bar]})
+      assert (%Tuple{elements: [:foo, @any]} <|> %Tuple{elements: [@any, :bar]}) ==
+        (%Tuple{elements: [@any, :bar]} <|> %Tuple{elements: [:foo, @any]} <|> %Tuple{elements: [:foo, :bar]})
 
       assert %Tuple{elements: [1..2, 1..2]} == (
-        %Tuple{elements: [1, 2]} |
-        %Tuple{elements: [2, 1]} |
-        %Tuple{elements: [1, 1]} |
+        %Tuple{elements: [1, 2]} <|>
+        %Tuple{elements: [2, 1]} <|>
+        %Tuple{elements: [1, 1]} <|>
         %Tuple{elements: [2, 2]}
       )
     end
@@ -172,16 +180,16 @@ defmodule TypeTest.UnionTest do
     test "complicated tuples can be merged" do
       # This should not be able to be solved without a more complicated SAT solver.
       unless %Tuple{elements: [1..3, 1..3, 1..3]} == (
-        %Tuple{elements: [(1 | 2), (2 | 3), Union.of(1, 3)]} |
-        %Tuple{elements: [(2 | 3), (1 | 3), Union.of(1, 2)]} |
-        %Tuple{elements: [(1 | 3), (1 | 2), Union.of(2, 3)]}
+        %Tuple{elements: [(1 <|> 2), (2 <|> 3), Union.of(1, 3)]} <|>
+        %Tuple{elements: [(2 <|> 3), (1 <|> 3), Union.of(1, 2)]} <|>
+        %Tuple{elements: [(1 <|> 3), (1 <|> 2), Union.of(2, 3)]}
       ) do
         IO.warn("this test can't be solved without a SAT solver")
       end
     end
 
     test "orthogonal tuples don't merge" do
-      assert %Type.Union{} = (%Type.Tuple{elements: [:foo, builtin(:integer)]} |
+      assert %Type.Union{} = (%Type.Tuple{elements: [:foo, builtin(:integer)]} <|>
                               %Type.Tuple{elements: [:bar, builtin(:float)]})
     end
   end
@@ -190,29 +198,29 @@ defmodule TypeTest.UnionTest do
 
   describe "for the list type" do
     test "lists with the same end type get merged" do
-      assert %List{type: (:foo | :bar)} == (%List{type: :foo} | %List{type: :bar})
-      assert %List{type: @any} == (%List{type: @any} | %List{type: :bar})
+      assert %List{type: (:foo <|> :bar)} == (%List{type: :foo} <|> %List{type: :bar})
+      assert %List{type: @any} == (%List{type: @any} <|> %List{type: :bar})
 
-      assert %List{type: (:foo | :bar), final: :end} ==
-        (%List{type: :foo, final: :end} | %List{type: :bar, final: :end})
+      assert %List{type: (:foo <|> :bar), final: :end} ==
+        (%List{type: :foo, final: :end} <|> %List{type: :bar, final: :end})
       assert %List{type: @any, final: :end} ==
-        (%List{type: @any, final: :end} | %List{type: :bar, final: :end})
+        (%List{type: @any, final: :end} <|> %List{type: :bar, final: :end})
     end
 
     test "nonempty: true lists get merged into nonempty: true lists" do
-      assert %List{type: (:foo | :bar), nonempty: true} ==
-        (%List{type: :foo, nonempty: true} | %List{type: :bar, nonempty: true})
+      assert %List{type: (:foo <|> :bar), nonempty: true} ==
+        (%List{type: :foo, nonempty: true} <|> %List{type: :bar, nonempty: true})
       assert %List{type: @any, nonempty: true} ==
-        (%List{type: @any, nonempty: true} | %List{type: :bar, nonempty: true})
+        (%List{type: @any, nonempty: true} <|> %List{type: :bar, nonempty: true})
     end
 
     test "nonempty: true lists get turned into nonempty: false lists when empty is added" do
-      assert %List{} = ([] | %List{nonempty: true})
+      assert %List{} = ([] <|> %List{nonempty: true})
     end
 
     test "nonempty: true lists get merged into nonempty: false lists" do
-      assert %List{type: :foo} = (%List{type: :foo} | %List{type: :foo, nonempty: true})
-      assert %List{type: @any} = (%List{type: @any} | %List{type: :foo, nonempty: true})
+      assert %List{type: :foo} = (%List{type: :foo} <|> %List{type: :foo, nonempty: true})
+      assert %List{type: @any} = (%List{type: @any} <|> %List{type: :foo, nonempty: true})
     end
   end
 end

--- a/test/union_test.exs
+++ b/test/union_test.exs
@@ -43,6 +43,10 @@ defmodule TypeTest.UnionTest do
     test "a preceding range is merged in" do
       assert 1..3 == (3 <|> 1..2)
     end
+    
+    test "an internal integer is merged" do
+      assert 1..2 == 1 <|> 1..2
+    end
   end
 
   describe "when collecting ranges in unions" do
@@ -162,12 +166,12 @@ defmodule TypeTest.UnionTest do
     end
 
     test "tuples are merged if their elements can merge" do
-      assert %Tuple{elements: [@any, :bar]} == (%Tuple{elements: [@any, :bar]} <|> %Tuple{elements: [:foo, :bar]})
-
-      assert %Tuple{elements: [:bar, @any]} == (%Tuple{elements: [:bar, @any]} <|> %Tuple{elements: [:bar, :foo]})
-
-      assert (%Tuple{elements: [:foo, @any]} <|> %Tuple{elements: [@any, :bar]}) ==
-        (%Tuple{elements: [@any, :bar]} <|> %Tuple{elements: [:foo, @any]} <|> %Tuple{elements: [:foo, :bar]})
+#      assert %Tuple{elements: [@any, :bar]} == (%Tuple{elements: [@any, :bar]} <|> %Tuple{elements: [:foo, :bar]})
+#
+#      assert %Tuple{elements: [:bar, @any]} == (%Tuple{elements: [:bar, @any]} <|> %Tuple{elements: [:bar, :foo]})
+#
+#      assert (%Tuple{elements: [:foo, @any]} <|> %Tuple{elements: [@any, :bar]}) ==
+#        (%Tuple{elements: [@any, :bar]} <|> %Tuple{elements: [:foo, @any]} <|> %Tuple{elements: [:foo, :bar]})
 
       assert %Tuple{elements: [1..2, 1..2]} == (
         %Tuple{elements: [1, 2]} <|>

--- a/test/union_test.exs
+++ b/test/union_test.exs
@@ -31,7 +31,11 @@ defmodule TypeTest.UnionTest do
     end
 
     test "when you send a union into collectible, it gets unwrapped" do
-      assert %Union{of: [7, 5, 3, 1]} = Enum.into([%Union{of: [1, 5]}, %Union{of: [3, 7]}], %Union{})
+      assert %Union{of: [7, 5, 3, 1]} = Enum.into([%Union{of: [5, 1]}, %Union{of: [7, 3]}], %Union{})
+    end
+
+    test "you can into a unions and it will be ordered as epexected" do
+      assert %Union{of: [5, 3, 1]} = Union.of(3 <|> 5, 1)
     end
   end
 
@@ -43,7 +47,7 @@ defmodule TypeTest.UnionTest do
     test "a preceding range is merged in" do
       assert 1..3 == (3 <|> 1..2)
     end
-    
+
     test "an internal integer is merged" do
       assert 1..2 == 1 <|> 1..2
     end
@@ -166,12 +170,12 @@ defmodule TypeTest.UnionTest do
     end
 
     test "tuples are merged if their elements can merge" do
-#      assert %Tuple{elements: [@any, :bar]} == (%Tuple{elements: [@any, :bar]} <|> %Tuple{elements: [:foo, :bar]})
-#
-#      assert %Tuple{elements: [:bar, @any]} == (%Tuple{elements: [:bar, @any]} <|> %Tuple{elements: [:bar, :foo]})
-#
-#      assert (%Tuple{elements: [:foo, @any]} <|> %Tuple{elements: [@any, :bar]}) ==
-#        (%Tuple{elements: [@any, :bar]} <|> %Tuple{elements: [:foo, @any]} <|> %Tuple{elements: [:foo, :bar]})
+      assert %Tuple{elements: [@any, :bar]} == (%Tuple{elements: [@any, :bar]} <|> %Tuple{elements: [:foo, :bar]})
+
+      assert %Tuple{elements: [:bar, @any]} == (%Tuple{elements: [:bar, @any]} <|> %Tuple{elements: [:bar, :foo]})
+
+      assert (%Tuple{elements: [:foo, @any]} <|> %Tuple{elements: [@any, :bar]}) ==
+        (%Tuple{elements: [@any, :bar]} <|> %Tuple{elements: [:foo, @any]} <|> %Tuple{elements: [:foo, :bar]})
 
       assert %Tuple{elements: [1..2, 1..2]} == (
         %Tuple{elements: [1, 2]} <|>
@@ -184,9 +188,9 @@ defmodule TypeTest.UnionTest do
     test "complicated tuples can be merged" do
       # This should not be able to be solved without a more complicated SAT solver.
       unless %Tuple{elements: [1..3, 1..3, 1..3]} == (
-        %Tuple{elements: [(1 <|> 2), (2 <|> 3), Union.of(1, 3)]} <|>
-        %Tuple{elements: [(2 <|> 3), (1 <|> 3), Union.of(1, 2)]} <|>
-        %Tuple{elements: [(1 <|> 3), (1 <|> 2), Union.of(2, 3)]}
+        %Tuple{elements: [1 <|> 2, 2 <|> 3, 1 <|> 3]} <|>
+        %Tuple{elements: [2 <|> 3, 1 <|> 3, 1 <|> 2]} <|>
+        %Tuple{elements: [1 <|> 3, 1 <|> 2, 2 <|> 3]}
       ) do
         IO.warn("this test can't be solved without a SAT solver")
       end
@@ -199,7 +203,6 @@ defmodule TypeTest.UnionTest do
   end
 
   alias Type.List
-
   describe "for the list type" do
     test "lists with the same end type get merged" do
       assert %List{type: (:foo <|> :bar)} == (%List{type: :foo} <|> %List{type: :bar})


### PR DESCRIPTION
completes refactoring of union and intersections to use the `<|>` and `<~>` operators since `|` is moving to `Kernel.SpecialForms`