### PR TITLE
Misc doc changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,4 @@
-# Mavis version
-
-## 0.0.1
-
-initial push, with full functionality across most of elixir standard library
+# Changelog
 
 ## 0.0.2
 
@@ -12,3 +8,7 @@ some touchup:
 - better intro documentation
 - support for fictional `String.t/1` type; this will
   probably be pulled out into a plugin in the future.
+
+## 0.0.1
+
+initial push, with full functionality across most of elixir standard library

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,19 @@
 Copyright 2020 Isaac T Yonemoto
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # Mavis
 
-![Elixir CI](https://github.com/ityonemo/mavis/workflows/Elixir%20CI/badge.svg)
+[![github.com](https://github.com/ityonemo/mavis/workflows/Elixir%20CI/badge.svg)](https://github.com/ityonemo/mavis/actions)
+[![hex.pm](https://img.shields.io/hexpm/v/mavis.svg)](https://hex.pm/packages/mavis)
+[![hexdocs.pm](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/mavis/)
+[![hex.pm](https://img.shields.io/hexpm/dt/mavis.svg)](https://hex.pm/packages/mavis)
+[![hex.pm](https://img.shields.io/hexpm/l/mavis.svg)](https://hex.pm/packages/mavis)
+[![github.com](https://img.shields.io/github/last-commit/ityonemo/mavis.svg)](https://github.com/ityonemo/mavis/commits/master)
 
-Advanced type system for Elixir
+Advanced type system for Elixir.
 
 ## Installation
 
-The package can be installed by adding `mavis` to your list of dependencies in `mix.exs`:
+Add `mavis` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
@@ -15,6 +20,3 @@ def deps do
   ]
 end
 ```
-
-The docs can be found at [https://hexdocs.pm/mavis](https://hexdocs.pm/mavis).
-

--- a/lib/type.ex
+++ b/lib/type.ex
@@ -7,13 +7,13 @@ defmodule Type do
   specifically tailored for the BEAM VM.  The following considerations went
   into its design.
 
-  - Must be compatible with the exisiting dialyzer/typespec system
+  - Must be compatible with the existing dialyzer/typespec system
   - May extend the typespec system if it's unobtrusive and can be, at
     a minimum, *'opt-out'*.
   - Does not have to conform to existing theoretical typesystems (e.g.
     [H-M](https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system))
   - Take maximum advantage of Elixir programming features to achieve
-    readibility and extensibility.
+    readability and extensibility.
   - Does not have to be easily usable from erlang, but must be able to
     handle modules produced in erlang.
 
@@ -65,14 +65,14 @@ defmodule Type do
   The `Type` module implements two things:
 
   1. Core functionality for all typesytem operations.
-  2. Support datastructure for generic builtin and remote types.
+  2. Support data structure for generic builtin and remote types.
 
   ## Type representation in Mavis
 
-  The `Type` datastructure is a struct with three parameters:
+  The `Type` data structure is a struct with three parameters:
   - `module`: The module in which the type is defined; `nil` for builtins.
   - `name`: (atom) of the type
-  - `params`: a list of type arguments to the type datastructure.  These
+  - `params`: a list of type arguments to the type data structure.  These
     must be types themselves "as applied" to the type definition if we
     consider it to be a function.
 
@@ -98,7 +98,7 @@ defmodule Type do
 
   ## Supported Type operations
 
-  The mavis typesystem provides five primary operations, which might not
+  The Mavis typesystem provides five primary operations, which might not
   necessarily be the set of operations that one expects from a typesystem.
   These operations are chosen specifically reflect the needs of Erlang and
   Elixir's dynamic types and the type specification system provided by
@@ -239,7 +239,7 @@ defmodule Type do
   @type maybe :: {:maybe, [Type.Message.t]}
 
   @typedoc """
-  No members of this type will suceed in the operation.
+  No members of this type will succeed in the operation.
 
   should typically result in a compile-time error.
 
@@ -1021,7 +1021,7 @@ defmodule Type do
 
   ## Important:
   Note the argument order for this function, it does not have the
-  same call order, as say, javascipt's `instanceof`, or ruby's `.is_a?`
+  same call order, as say, JavaScript's `instanceof`, or ruby's `.is_a?`
 
   ### Example:
   ```elixir

--- a/lib/type/_helpers.ex
+++ b/lib/type/_helpers.ex
@@ -113,7 +113,7 @@ defmodule Type.Helpers do
   Prologue function matches:
   - matches itself and returns itself
   - matches `t:any/0` and returns itself
-  - calcualates intersections for remote types
+  - calculates intersections for remote types
   - intersects union types
   - intersects function var types
   """

--- a/lib/type/_no_inference.ex
+++ b/lib/type/_no_inference.ex
@@ -20,7 +20,7 @@ defmodule Type.NoInference do
 
   @impl true
   @doc """
-  function which assumes that any lambda passed to it takes any parameters and
+  Function which assumes that any lambda passed to it takes any parameters and
   outputs any.  Punts on inferring from MFA definitions.
 
   ```

--- a/lib/type/_operators.ex
+++ b/lib/type/_operators.ex
@@ -1,7 +1,8 @@
 defmodule Type.Operators do
+  @moduledoc """
+  Convenience functions.  Should only be used in testing.
+  """
 
-  @moduledoc "convenience functions.  Should only be used in testing."
-  
   defmacro __using__(_opts) do
     quote do
       import Kernel, except: [>: 2, <: 2, <=: 2, >=: 2, in: 2]
@@ -12,22 +13,22 @@ defmodule Type.Operators do
   import Kernel, except: [>: 2, <: 2, <=: 2, >=: 2, in: 2]
 
   @doc """
-  shortcut for `Type.usable_as/2`
+  Shortcut for `Type.usable_as/2`
   """
   def a ~> b, do: Type.usable_as(a, b)
 
   @doc """
-  shortcut for `Type.union/2`
+  Shortcut for `Type.union/2`
   """
   defdelegate a <|> b, to: Type.Union, as: :of
 
   @doc """
-  shortcut for `Type.intersection/2`
+  Shortcut for `Type.intersection/2`
   """
   defdelegate a <~> b, to: Type, as: :intersection
 
   @doc """
-  shortcut for `Type.compare/2`
+  Shortcut for `Type.compare/2`
   """
   def a >= b, do: Type.compare(a, b) != :lt
   def a <= b, do: Type.compare(a, b) != :gt

--- a/lib/type/bitstring.ex
+++ b/lib/type/bitstring.ex
@@ -47,7 +47,7 @@ defmodule Type.Bitstring do
 
   #### intersection
 
-  some binaries have no intersection, but mavis will find obscure intersections.
+  Some binaries have no intersection, but Mavis will find obscure intersections.
 
   ```elixir
   iex> Type.intersection(%Type.Bitstring{size: 15, unit: 0}, %Type.Bitstring{size: 3, unit: 0})
@@ -62,7 +62,7 @@ defmodule Type.Bitstring do
 
   #### union
 
-  most binary pairs won't have nontrivial unions, but mavis will find some obscure ones.
+  Most binary pairs won't have nontrivial unions, but Mavis will find some obscure ones.
 
   ```elixir
   iex> Type.union(%Type.Bitstring{size: 0, unit: 1}, %Type.Bitstring{size: 15, unit: 8})
@@ -73,7 +73,7 @@ defmodule Type.Bitstring do
 
   #### subtype?
 
-  a bitstring type is a subtype of another if its lattice is covered by the other's
+  A bitstring type is a subtype of another if its lattice is covered by the other's.
 
   ```elixir
   iex> Type.subtype?(%Type.Bitstring{size: 16, unit: 8}, %Type.Bitstring{size: 4, unit: 4})
@@ -84,7 +84,7 @@ defmodule Type.Bitstring do
 
   #### usable_as
 
-  most bitstrings are at least maybe usable as others, but there are cases where it's impossible
+  Most bitstrings are at least maybe usable as others, but there are cases where it's impossible.
 
   ```elixir
   iex> Type.usable_as(%Type.Bitstring{size: 8, unit: 16}, %Type.Bitstring{size: 4, unit: 4})
@@ -115,12 +115,12 @@ defmodule Type.Bitstring do
     use Type.Helpers
 
     group_compare do
-      def group_compare(%Bitstring{unit: 0}, %Bitstring{unit: b}) when b != 0, do: :lt 
-      def group_compare(%Bitstring{unit: a}, %Bitstring{unit: 0}) when a != 0, do: :gt 
-      def group_compare(%Bitstring{unit: a}, %Bitstring{unit: b}) when a < b,  do: :gt 
-      def group_compare(%Bitstring{unit: a}, %Bitstring{unit: b}) when a > b,  do: :lt 
-      def group_compare(%Bitstring{size: a}, %Bitstring{size: b}) when a < b,  do: :gt 
-      def group_compare(%Bitstring{size: a}, %Bitstring{size: b}) when a > b,  do: :lt 
+      def group_compare(%Bitstring{unit: 0}, %Bitstring{unit: b}) when b != 0, do: :lt
+      def group_compare(%Bitstring{unit: a}, %Bitstring{unit: 0}) when a != 0, do: :gt
+      def group_compare(%Bitstring{unit: a}, %Bitstring{unit: b}) when a < b,  do: :gt
+      def group_compare(%Bitstring{unit: a}, %Bitstring{unit: b}) when a > b,  do: :lt
+      def group_compare(%Bitstring{size: a}, %Bitstring{size: b}) when a < b,  do: :gt
+      def group_compare(%Bitstring{size: a}, %Bitstring{size: b}) when a > b,  do: :lt
 
       def group_compare(left, %Type{module: String, name: :t}) do
         left

--- a/lib/type/function.ex
+++ b/lib/type/function.ex
@@ -1,7 +1,7 @@
 defmodule Type.Function do
 
   @moduledoc """
-  represents a function type.
+  Represents a function type.
 
   There are two fields for the struct defined by this module.
 

--- a/lib/type/list.ex
+++ b/lib/type/list.ex
@@ -1,6 +1,6 @@
 defmodule Type.List do
   @moduledoc """
-  represents lists, except for the empty list, which is represented by
+  Represents lists, except for the empty list, which is represented by
   the empty list literal `[]`.
 
   There are three fields for the struct defined by this module.
@@ -8,12 +8,12 @@ defmodule Type.List do
   - `nonempty` if true, the list must have at least one element; if false, then
     it may be the empty list `[]`.
   - `type` the type for all elements of the list, except the final element
-  - `final` the type of the final elment.  Typically this is `[]`, but other
+  - `final` the type of the final element.  Typically this is `[]`, but other
     types may be used as the final element and these are called `improper` lists.
 
   ### Examples:
 
-  - the "any proper list" type is `%Type.List{}`.  Note this is distinct from `[]`
+  - The "any proper list" type is `%Type.List{}`.  Note this is distinct from `[]`
     ```
     iex> inspect %Type.List{}
     "list()"

--- a/lib/type/map.ex
+++ b/lib/type/map.ex
@@ -1,7 +1,7 @@
 defmodule Type.Map do
 
   @moduledoc """
-  represents map terms.  Note that some of the choices around how to handle
+  Represents map terms.  Note that some of the choices around how to handle
   maps may deviate from the expectations in the typesystem.
 
   The associated struct has two parameters:
@@ -17,7 +17,7 @@ defmodule Type.Map do
   - map types will not by default assume `optional(any()) => any()`
   - If multiple specifications exist for the same particular value (for example,
     overlapping ranges in optional keys, or a overlapping types in required vs
-    optional), all specfications are applied to that value group.  This may
+    optional), all specifications are applied to that value group.  This may
     result in the map being equivalent to `%Type{name: :none}` but that will
     not automatically be collapsed to that value.
 
@@ -289,7 +289,7 @@ defmodule Type.Map do
 
   # performs an apply operation on either the required part or the
   # optional part of a map type.  Returns a list of images.  You
-  # should perfrom the union operation *outside* this function
+  # should perform the union operation *outside* this function
   defp apply_partial(req_or_opt, preimage_subtype) do
     import Type, only: [builtin: 1]
     req_or_opt
@@ -425,7 +425,7 @@ defmodule Type.Map do
       |> Enum.uniq
 
       # check that all required keys exist in the preimage intersection, if
-      # it doesn't then we can do an early eiit.
+      # it doesn't then we can do an early edit.
       if Enum.all?(all_req_keys, &Type.subtype?(&1, preimage_intersection)) do
         req_kv = all_req_keys
         |> Enum.map(fn rq_key ->

--- a/lib/type/opaque.ex
+++ b/lib/type/opaque.ex
@@ -1,6 +1,6 @@
 defmodule Type.Opaque do
   @moduledoc """
-  a wrapper for opaqueness.
+  A wrapper for opaqueness.
   """
 
   @enforce_keys [:module, :name, :params, :type]

--- a/lib/type/tuple.ex
+++ b/lib/type/tuple.ex
@@ -1,7 +1,6 @@
 defmodule Type.Tuple do
-
   @moduledoc """
-  represents tuple types.
+  Represents tuple types.
 
   The associated struct has one parameter:
   - `:elements` which may be a list of types, corresponding to the ordered
@@ -27,7 +26,7 @@ defmodule Type.Tuple do
 
   #### comparison
 
-  longer tuples come after shorter tuples; tuples are then ordered using cartesian
+  Longer tuples come after shorter tuples; tuples are then ordered using Cartesian
   dictionary order along the elements list.
 
   ```
@@ -38,7 +37,7 @@ defmodule Type.Tuple do
 
   #### intersection
 
-  Tuples of different length do not intersect; the intersection is otherwise the cartesian
+  Tuples of different length do not intersect; the intersection is otherwise the Cartesian
   intersection of the elements.
 
   ```
@@ -65,7 +64,7 @@ defmodule Type.Tuple do
   #### subtype?
 
   A tuple type is the subtype of another if its types are subtypes of the other
-  across all cartesian dimensions.
+  across all Cartesian dimensions.
 
   ```
   iex> Type.subtype?(%Type.Tuple{elements: [:ok, 1..10]},
@@ -76,7 +75,7 @@ defmodule Type.Tuple do
   #### usable_as
 
   A tuple type is usable as another if it each of its elements are usable as
-  the other across all cartesian dimensions.  If any element is disjoint, then
+  the other across all Cartesian dimensions.  If any element is disjoint, then
   it is not usable.
 
   ```

--- a/lib/type/union.ex
+++ b/lib/type/union.ex
@@ -1,11 +1,11 @@
 defmodule Type.Union do
   @moduledoc """
-  represents the Union of two or more types.
+  Represents the Union of two or more types.
 
-  the associated struct has one field:
+  The associated struct has one field:
   - `:of` which is a list of all types that are being unioned.
 
-  for performance purposes, Union keeps its subtypes in
+  For performance purposes, Union keeps its subtypes in
   reverse-type-order.
 
   Type.Union implements both the enumerable protocol and the

--- a/mix.exs
+++ b/mix.exs
@@ -1,35 +1,21 @@
 defmodule Mavis.MixProject do
   use Mix.Project
 
+  @source_url "https://github.com/ityonemo/mavis"
   @version "0.0.2"
-  @source_url "https://github.com/ityonemo/mavis/"
 
   def project do
     [
       app: :mavis,
       version: @version,
       elixir: "~> 1.10",
+      package: package(),
       test_coverage: [tool: ExCoveralls],
-      package: [
-        description: "type system tools for elixir",
-        licenses: ["MIT"],
-        files: ~w(lib .formatter.exs mix.exs README* LICENSE* VERSIONS*),
-        links: %{"GitHub" => @source_url}
-      ],
-      source_url: @source_url,
-      preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test],
+      preferred_cli_env: preferred_cli_env(),
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
-      docs: [
-        source_ref: @version,
-        main: "Type",
-        groups_for_modules: [
-          "Types": [Type.AsBoolean, Type.Bitstring, Type.Function,
-          Type.Function.Var, Type.List, Type.Map, Type.Opaque, Type.Tuple,
-          Type.Union]
-        ]
-      ]
+      docs: docs()
     ]
   end
 
@@ -38,10 +24,56 @@ defmodule Mavis.MixProject do
   defp elixirc_paths(:test), do: ["lib", "test/_support"]
   defp elixirc_paths(_), do: ["lib"]
 
-  defp deps, do: [
-    {:credo, "~> 1.2", only: [:test, :dev], runtime: false},
-    {:ex_doc, "~> 0.23", only: :dev, runtime: :false},
-    {:excoveralls, "~> 0.11.1", only: :test}
-  ]
+  defp package do
+    [
+      description: "Type system tools for elixir",
+      licenses: ["MIT"],
+      files: ~w(lib .formatter.exs mix.exs README* LICENSE* CHANGELOG*),
+      links: %{
+        "Changelog" => "#{@source_url}/blob/master/CHANGELOG.md",
+        "GitHub" => @source_url
+      }
+    ]
+  end
 
+  defp deps do
+    [
+      {:credo, "~> 1.2", only: [:test, :dev], runtime: false},
+      {:ex_doc, "~> 0.23", only: :dev, runtime: false},
+      {:excoveralls, "~> 0.11.1", only: :test}
+    ]
+  end
+
+  defp preferred_cli_env do
+    [
+      coveralls: :test,
+      "coveralls.detail": :test,
+      "coveralls.post": :test,
+      "coveralls.html": :test
+    ]
+  end
+
+  defp docs do
+    [
+      main: "Type",
+      source_ref: @version,
+      source_url: @source_url,
+      groups_for_modules: [
+        Types: [
+          Type.AsBoolean,
+          Type.Bitstring,
+          Type.Function,
+          Type.Function.Var,
+          Type.List,
+          Type.Map,
+          Type.Opaque,
+          Type.Tuple,
+          Type.Union
+        ]
+      ],
+      extras: [
+        "CHANGELOG.md"
+      ]
+    ]
+  end
 end

--- a/typesystem.md
+++ b/typesystem.md
@@ -1,11 +1,9 @@
 # The Mavis Typesystem
 
-The Mavis typesystem features two distinct and unique
-concepts which were conceived of as tool specialized for
-the BEAM virtual machine's type system, and can be
-considered a refinement built on top of the type specs
-that are used by `dialyzer`, the legacy erlang
-type-checking system.
+The Mavis typesystem features two distinct and unique concepts which were
+conceived of as tool specialized for the BEAM virtual machine's type system,
+and can be considered a refinement built on top of the type specs that are used
+by `dialyzer`, the legacy erlang type-checking system.
 
 - `subtype` roughly corresponds to what you might expect, `A subtype B`
   means that the all elements of type A are subtypes of element B
@@ -19,12 +17,12 @@ could emit a warning and an `error` result could halt compilation.
 In the Mavis Library,
 
 ```elixir
-  use Type.Operators
+use Type.Operators
 ```
 
 overloads `~>` as `usable_as` and `in` as `subtype_of`
 
-**Be exremely careful!** you should only use `Type.Operators` if you really
+**Be extremely careful!** you should only use `Type.Operators` if you really
 know what you're doing.  In the case of Mavis, this is used exclusively to
 make tests easier to read.
 


### PR DESCRIPTION
List of changes:
- Fix typos, training spaces, and wording
- Clean up module config
- Rename and format Changelog file
- Format license file
- Word wrap doc
- Add changelog link to hex module info page
- Fix indentation
- Badges and more badges!